### PR TITLE
Activity api

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,7 +63,7 @@ All hard-to-use functionality is automatically scoped and managed, making it nat
 .. code:: python3
 
    # scoping is a builtin concept of usim
-   async with out(time >= 3000) as scope:
+   async with until(time >= 3000) as scope:
       # complex tools are automatically managed
       async for message in stream:
          scope.do(handle(message))

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -2,18 +2,23 @@
 Glossary of Terms
 =================
 
+.. Using references in the glossary itself:
+   When mentioning other items, always reference them.
+   When mention the current item, never reference it.
+
 
 .. glossary::
 
     Activity
-        Ongoing action that drives forward a simulation - either through time or events.
-        Activities may be suspended and resumed as desired, or interrupted involuntarily.
+        Ongoing action that drives forward a simulation - either through :term:`time` or :term:`events <event>`.
+        Activities may be :term:`suspended <Suspension>` and resumed as desired, or interrupted involuntarily.
 
     Time
         Representation of the progression of a simulation.
         Whereas the unit of time is arbitrary, its value always grows.
 
-        Time may only pass while all :term:`activities <Activity>` are *suspended*.
+        Time may only pass while all :term:`activities <Activity>`
+        are :term:`postponed <Postponement>` until a later time, not :term:`turn`.
         An :term:`activity` may actively wait for the progression of time,
         or implicitly delay until an event happens at a future point in time.
 
@@ -23,10 +28,31 @@ Glossary of Terms
     Event
         A well-defined occurrence at a specific point in :term:`time`.
         Events may occur
-        as result of activities ("dinner is done"),
+        as result of activities ("when dinner is done"),
         as time passes ("after 20 time units"),
         or
         at predefined points in time ("at 2000 time units"),
 
     Notification
         Information sent to an :term:`activity`, usually in response to an :term:`event`.
+        Notifications can only be received when an :term:`activity` is :term:`suspended <Suspension>`.
+
+    Postponement
+        :term:`Suspension` of an :term:`activity` until a later :term:`turn` at the same :term:`time`.
+        When an :term:`activity` is postponed,
+        other :term:`activities <Activity>` may run but :term:`time` does not advance.
+        If there are no other :term:`activities <Activity>` to resume,
+        a postponed :term:`activity` is resumed immediately.
+
+        :note: μSim guarantees that all its primitives postpone on asynchronous operations.
+               This ensures that activities are reliably and deterministically interwoven.
+
+    Suspension
+        Pause in the execution of an :term:`activity`,
+        allowing other :term:`activities <activity>` or :term:`time` to advance.
+        A suspended activity is only resumed when it receives a :term:`notification`.
+
+        Suspension can only occur as part of asynchronous statements:
+        waiting for the target of an ``await`` statement,
+        fetching the next item of an ``async for`` statement,
+        and entering/exiting an ``async with`` block.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -4,7 +4,7 @@ Glossary of Terms
 
 .. Using references in the glossary itself:
    When mentioning other items, always reference them.
-   When mention the current item, never reference it.
+   When mentioning the current item, never reference it.
 
 
 .. glossary::

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -18,7 +18,7 @@ Glossary of Terms
         Whereas the unit of time is arbitrary, its value always grows.
 
         Time may only pass while all :term:`activities <Activity>`
-        are :term:`postponed <Postponement>` until a later time, not :term:`turn`.
+        are :term:`suspended <Suspension>` until a later time, not :term:`turn`.
         An :term:`activity` may actively wait for the progression of time,
         or implicitly delay until an event happens at a future point in time.
 
@@ -35,20 +35,19 @@ Glossary of Terms
 
     Notification
         Information sent to an :term:`activity`, usually in response to an :term:`event`.
-        Notifications can only be received when an :term:`activity` is :term:`suspended <Suspension>`.
+        Notifications are only received when the :term:`activity`
+        is :term:`suspended <Suspension>`, i.e. at an ``await``, ``async for`` or ``async with``.
 
     Postponement
         :term:`Suspension` of an :term:`activity` until a later :term:`turn` at the same :term:`time`.
-        When an :term:`activity` is postponed,
-        other :term:`activities <Activity>` may run but :term:`time` does not advance.
-        If there are no other :term:`activities <Activity>` to resume,
-        a postponed :term:`activity` is resumed immediately.
+        When an :term:`activity` is postponed, :term:`notifications <Notification>` may be received
+        and other :term:`activities <Activity>` may run but :term:`time` does not advance.
 
         :note: μSim guarantees that all its primitives postpone on asynchronous operations.
                This ensures that activities are reliably and deterministically interwoven.
 
     Suspension
-        Pause in the execution of an :term:`activity`,
+        Pause the execution of an :term:`activity`,
         allowing other :term:`activities <activity>` or :term:`time` to advance.
         A suspended activity is only resumed when it receives a :term:`notification`.
 

--- a/docs/source/tutorial/03_scopes.rst
+++ b/docs/source/tutorial/03_scopes.rst
@@ -36,7 +36,7 @@ We again use ``usim.time`` to track and influence the progression of our simulat
     ...         await (time + 1)                       # 3
     ...         drivers.do(deliver_one(3))
     ...         print('Sent deliveries at', time.now)  # 4.1
-    ...     print('-- Done deliveries at', time.now)      # 4.2
+    ...     print('-- Done deliveries at', time.now)   # 4.2
 
 Scopes can be difficult because they are inherently about doing several things at once.
 It helps to step through individual points of notice:

--- a/docs/source/tutorial/04_cancel_scope.rst
+++ b/docs/source/tutorial/04_cancel_scope.rst
@@ -4,7 +4,7 @@ Interlude 01: Interrupting Scopes
 
 .. code:: python3
 
-    >>> from usim import time, until as out
+    >>> from usim import time, until
     >>>
     >>> async def deliver_one(which):
     ...     print('Delivering', which, 'at', time.now)

--- a/docs/source/tutorial/04_cancel_scope.rst
+++ b/docs/source/tutorial/04_cancel_scope.rst
@@ -1,0 +1,21 @@
+
+Interlude 01: Interrupting Scopes
+---------------------------------
+
+.. code:: python3
+
+    >>> from usim import time, until as out
+    >>>
+    >>> async def deliver_one(which):
+    ...     print('Delivering', which, 'at', time.now)
+    ...     await (time + 5)
+    ...     print('Delivered', which, 'at', time.now)
+    >>>
+    >>> async def deliver_all(count=3):
+    ...     print('-- Start deliveries at', time.now)
+    ...     async with out(time + 10) as deliveries:   # 1
+    ...         for delivery in range(count):          # 2
+    ...             deliveries.do(deliver_one(delivery))
+    ...             await (time + 3)
+    ...         print('Sent deliveries at', time.now)  # 4.1
+    ...     print('-- Done deliveries at', time.now)   # 4.2

--- a/docs/source/tutorial/04_cancel_scope.rst
+++ b/docs/source/tutorial/04_cancel_scope.rst
@@ -13,7 +13,7 @@ Interlude 01: Interrupting Scopes
     >>>
     >>> async def deliver_all(count=3):
     ...     print('-- Start deliveries at', time.now)
-    ...     async with out(time + 10) as deliveries:   # 1
+    ...     async with until(time + 10) as deliveries:   # 1
     ...         for delivery in range(count):          # 2
     ...             deliveries.do(deliver_one(delivery))
     ...             await (time + 3)

--- a/usim/__init__.py
+++ b/usim/__init__.py
@@ -5,14 +5,14 @@ from ._core.loop import Loop as _Loop
 from ._primitives.timing import Time, Eternity, Instant, each
 from ._primitives.flag import Flag
 from ._primitives.locks import Lock
-from ._primitives.context import until, Scope, VolatileActivityExit
-from ._primitives.activity import ActivityCancelled, ActivityState
+from ._primitives.context import until, Scope, VolatileTaskExit
+from ._primitives.task import TaskCancelled, TaskState
 
 
 __all__ = [
     'run',
     'time', 'eternity', 'instant', 'each',
-    'until', 'Scope', 'ActivityCancelled', 'VolatileActivityExit', 'ActivityState',
+    'until', 'Scope', 'TaskCancelled', 'VolatileTaskExit', 'TaskState',
     'Flag', 'Lock',
 ]
 

--- a/usim/_primitives/activity.py
+++ b/usim/_primitives/activity.py
@@ -76,7 +76,7 @@ class Activity(Awaitable[RT]):
     * :py:meth:`~.Activity.cancel` an :py:class:`Activity` before completion,
     * ``await`` the result of an :py:class:`Activity` multiple times,
       and
-    * ``await`` that an is an :py:class:`Activity` is :py:meth:`~.Activity.done`.
+    * ``await`` that an is an :py:class:`Activity` is :py:attr:`~.Activity.done`.
 
     :note: This class should not be instantiated directly.
            Always use a :py:class:`~.Scope` to create it.
@@ -156,7 +156,7 @@ class Activity(Awaitable[RT]):
         The activity may catch and react to :py:class:`~.CancelActivity`,
         but should not suppress it.
 
-        If the :py:class:`~.Activity` is :py:meth:`~.Activity.done` before :py:class:`~.CancelActivity` is raised,
+        If the :py:class:`~.Activity` is :py:attr:`~.Activity.done` before :py:class:`~.CancelActivity` is raised,
         the cancellation is ignored.
         This also means that cancelling an activity multiple is allowed,
         but only the first successful cancellation is stored as the cancellation cause.

--- a/usim/_primitives/activity.py
+++ b/usim/_primitives/activity.py
@@ -51,7 +51,7 @@ class CancelActivity(Interrupt):
 
 
 class ActivityExit(BaseException):
-    ...
+    """A :py:class:`~.Activity` forcefully exited"""
 
 
 class Activity(Awaitable[RT]):

--- a/usim/_primitives/activity.py
+++ b/usim/_primitives/activity.py
@@ -56,7 +56,7 @@ class ActivityExit(BaseException):
 
 class Activity(Awaitable[RT]):
     """
-    Concurrently running activity that allows multiple activities to await its completion
+    Concurrently running activity that allows multiple objects including activities to await its completion
 
     A :py:class:`Activity` represents an activity that is concurrently run in a :py:class:`~.Scope`.
     This allows to store or pass an an :py:class:`Activity`, in order to check its progress.

--- a/usim/_primitives/activity.py
+++ b/usim/_primitives/activity.py
@@ -58,7 +58,7 @@ class Activity(Awaitable[RT]):
     """
     Concurrently running activity that allows multiple objects including activities to await its completion
 
-    An :py:class:`Activity` wraps an activity that is concurrently run in a :py:class:`~.Scope`.
+    An :py:class:`Activity` wraps an :term:`activity` that is concurrently run in a :py:class:`~.Scope`.
     This allows to store or pass around the :py:class:`Activity`, in order to check its progress.
     Other activities can ``await`` an :py:class:`Activity`,
     which returns any results or exceptions on completion, similar to a regular activity.

--- a/usim/_primitives/activity.py
+++ b/usim/_primitives/activity.py
@@ -58,25 +58,29 @@ class Activity(Awaitable[RT]):
     """
     Concurrently running activity that allows multiple objects including activities to await its completion
 
-    An :py:class:`Activity` represents an activity that is concurrently run in a :py:class:`~.Scope`.
-    This allows to store or pass an an :py:class:`Activity`, in order to check its progress.
+    An :py:class:`Activity` wraps an activity that is concurrently run in a :py:class:`~.Scope`.
+    This allows to store or pass around the :py:class:`Activity`, in order to check its progress.
     Other activities can ``await`` an :py:class:`Activity`,
     which returns any results or exceptions on completion, similar to a regular activity.
 
     .. code:: python3
 
-        await my_activity()  # await a bare activity
+        async def my_activity(delay):
+            await (time + delay)
+            return delay
+
+        await my_activity()  # await an unwrapped activity
 
         async with Scope() as scope:
             activity = scope.do(my_activity())
-            await activity   # await a rich activity
+            await activity   # await a wrapping Activity
 
-    In contrast to a regular activity, it is possible to
+    In contrast to a bare activity, it is possible to
 
     * :py:meth:`~.Activity.cancel` an :py:class:`Activity` before completion,
     * ``await`` the result of an :py:class:`Activity` multiple times,
       and
-    * ``await`` that an is an :py:class:`Activity` is :py:attr:`~.Activity.done`.
+    * ``await`` that an :py:class:`Activity` is :py:attr:`~.Activity.done`.
 
     :note: This class should not be instantiated directly.
            Always use a :py:class:`~.Scope` to create it.

--- a/usim/_primitives/activity.py
+++ b/usim/_primitives/activity.py
@@ -58,9 +58,9 @@ class Activity(Awaitable[RT]):
     """
     Concurrently running activity that allows multiple objects including activities to await its completion
 
-    A :py:class:`Activity` represents an activity that is concurrently run in a :py:class:`~.Scope`.
+    An :py:class:`Activity` represents an activity that is concurrently run in a :py:class:`~.Scope`.
     This allows to store or pass an an :py:class:`Activity`, in order to check its progress.
-    Other activities can ``await`` a :py:class:`Activity`,
+    Other activities can ``await`` an :py:class:`Activity`,
     which returns any results or exceptions on completion, similar to a regular activity.
 
     .. code:: python3
@@ -158,7 +158,7 @@ class Activity(Awaitable[RT]):
 
         If the :py:class:`~.Activity` is :py:attr:`~.Activity.done` before :py:class:`~.CancelActivity` is raised,
         the cancellation is ignored.
-        This also means that cancelling an activity multiple is allowed,
+        This also means that cancelling an activity multiple times is allowed,
         but only the first successful cancellation is stored as the cancellation cause.
 
         If the :py:class:`~.Activity` has not started running, it is cancelled immediately.
@@ -198,7 +198,7 @@ class Activity(Awaitable[RT]):
 
 
 class Done(Condition):
-    """Whether a :py:class:`Activity` has stopped running"""
+    """Whether an :py:class:`Activity` has stopped running"""
     __slots__ = ('_activity', '_value', '_inverse')
 
     def __init__(self, activity: Activity):
@@ -224,7 +224,7 @@ class Done(Condition):
 
 
 class NotDone(Condition):
-    """Whether a :py:class:`Activity` has not stopped running"""
+    """Whether an :py:class:`Activity` has not stopped running"""
     __slots__ = ('_done',)
 
     def __init__(self, done: Done):

--- a/usim/_primitives/condition.py
+++ b/usim/_primitives/condition.py
@@ -30,7 +30,7 @@ class Condition(Notification):
 
         await condition  # resume when condition is True
 
-        async with out(condition):  # interrupt when condition is True
+        async with until(condition):  # interrupt when condition is True
             ...
 
     Every :py:class:`~.Condition` supports the bitwise operators

--- a/usim/_primitives/condition.py
+++ b/usim/_primitives/condition.py
@@ -12,11 +12,11 @@ class Condition(Notification):
     """
     An asynchronous logical condition
 
-    Every :py:class:`~.Condition` can be used both in a
+    Every :py:class:`~.Condition` can be used both in an
     asynchronous *and* boolean context.
     In an asynchronous context,
     such as ``await``,
-    a :py:class:`~.Condition` triggers when :py:const:`True`.
+    a :py:class:`~.Condition` triggers when the :py:class:`~.Condition` becomes :py:const:`True`.
     In a boolean context,
     such as ``if``,
     a :py:class:`~.Condition` provides its current boolean value.

--- a/usim/_primitives/condition.py
+++ b/usim/_primitives/condition.py
@@ -10,14 +10,48 @@ from .._core.loop import __LOOP_STATE__
 
 class Condition(Notification):
     """
-    A logical condition that triggers when ``True``
+    An asynchronous logical condition
+
+    Every :py:class:`~.Condition` can be used both in a
+    asynchronous *and* boolean context.
+    In an asynchronous context,
+    such as ``await``,
+    a :py:class:`~.Condition` triggers when :py:const:`True`.
+    In a boolean context,
+    such as ``if``,
+    a :py:class:`~.Condition` provides its current boolean value.
 
     .. code:: python
 
+        if condition:    # resume with current value
+            print(condition, 'is met')
+        else:
+            print(condition, 'is not met')
+
         await condition  # resume when condition is True
 
-        async with until(condition):  # abort if condition becomes False
+        async with out(condition):  # interrupt when condition is True
             ...
+
+    Every :py:class:`~.Condition` supports the bitwise operators
+    ``~a`` (not),
+    ``a & b`` (and), and
+    ``a | b`` (or)
+    to derive a new :py:class:`~.Condition`.
+    While it is possible to use the boolean operators
+    ``not``, ``and``, and ``or``,
+    they immediately evaluate any :py:class:`~.Condition` in a boolean context.
+
+    .. code:: python
+
+        await (a & b)   # resume when both a and b are True
+        await (a | b)   # resume when one of a or b are True
+        await (a & ~b)  # resume when a is True and b is False
+
+        c = a & b  # derive new Condition...
+        await c    # that can be awaited
+
+        d = a and b  # force boolean evaluation
     """
     __slots__ = ()
 
@@ -88,7 +122,11 @@ class Connective(Condition):
 
 
 class All(Connective):
-    """Logical AND of all sub-conditions"""
+    """
+    Logical AND of all sub-conditions
+
+    The expression ``a & b & c`` is equivalent to ``All(a, b, c)``.
+    """
     __slots__ = ()
 
     def __bool__(self):
@@ -102,7 +140,11 @@ class All(Connective):
 
 
 class Any(Connective):
-    """Logical OR of all sub-conditions"""
+    """
+    Logical OR of all sub-conditions
+
+    The expression ``a | b | c`` is equivalent to ``Any(a, b, c)``.
+    """
     __slots__ = ()
 
     def __bool__(self):

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -66,7 +66,7 @@ class Scope:
         """
         child_activity = Activity(payload)
         __LOOP_STATE__.LOOP.schedule(
-            child_activity.__runner__(),
+            child_activity.__runner__,
             delay=after, at=at
         )
         if not volatile:

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -77,7 +77,7 @@ class Scope:
 
     async def _await_children(self):
         for child in self._children:
-            await child
+            await child.done
 
     def _cancel_children(self):
         for child in self._children:

--- a/usim/_primitives/locks.py
+++ b/usim/_primitives/locks.py
@@ -31,7 +31,7 @@ class Lock:
     @property
     def available(self):
         """
-        Check whether the current Activity can acquire this lock
+        Check whether the current Task can acquire this lock
         """
         if self._owner is None:
             return True

--- a/usim/typing.py
+++ b/usim/typing.py
@@ -1,11 +1,11 @@
 from ._primitives.notification import Notification
 from ._primitives.condition import Condition
-from ._primitives.activity import Activity
+from ._primitives.task import Task
 from ._basics.streams import Stream, StreamAsyncIterator
 
 
 __all__ = [
     'Notification', 'Condition',
     'Stream', 'StreamAsyncIterator',
-    'Activity',
+    'Task',
 ]

--- a/usim_pytest/test_scopes.py
+++ b/usim_pytest/test_scopes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from usim import Scope, time, eternity, VolatileActivityExit, ActivityState, ActivityCancelled, until, each
+from usim import Scope, time, eternity, VolatileTaskExit, TaskState, TaskCancelled, until, each
 
 from .utility import via_usim
 
@@ -37,14 +37,14 @@ class TestDo:
 
         async with Scope() as scope:
             activity = scope.do(payload(), after=5)
-            assert activity.status == ActivityState.CREATED
+            assert activity.status == TaskState.CREATED
             await (time + 4)
-            assert activity.status == ActivityState.CREATED
+            assert activity.status == TaskState.CREATED
             await (time + 3)
-            assert activity.status == ActivityState.RUNNING
+            assert activity.status == TaskState.RUNNING
             await activity.done
             assert time.now == 15
-            assert activity.status == ActivityState.SUCCESS
+            assert activity.status == TaskState.SUCCESS
 
     @via_usim
     async def test_at(self):
@@ -67,9 +67,9 @@ class TestDo:
 
         async with Scope() as scope:
             activity = scope.do(payload(), volatile=True)
-        with pytest.raises(VolatileActivityExit):
+        with pytest.raises(VolatileTaskExit):
             assert await activity
-        assert activity.status == ActivityState.FAILED
+        assert activity.status == TaskState.FAILED
 
     @via_usim
     async def test_after_and_at(self):
@@ -153,12 +153,12 @@ async def test_until():
         activity = running.do(scheduler())
 
     assert time.now == 500
-    with pytest.raises(ActivityCancelled):
+    with pytest.raises(TaskCancelled):
         await activity
 
 
 @via_usim
-@pytest.mark.xfail(raises=ActivityCancelled, strict=True)
+@pytest.mark.xfail(raises=TaskCancelled, strict=True)
 async def test_result():
     async def make_job():
         async with Scope() as scope:

--- a/usim_pytest/test_scopes.py
+++ b/usim_pytest/test_scopes.py
@@ -15,7 +15,7 @@ class TestDo:
         async with Scope() as scope:
             activity = scope.do(payload())
 
-        assert await activity.result == 2
+        assert await activity == 2
 
     @via_usim
     async def test_negative(self):
@@ -42,7 +42,7 @@ class TestDo:
             assert activity.status == ActivityState.CREATED
             await (time + 3)
             assert activity.status == ActivityState.RUNNING
-            await activity.result
+            await activity.done
             assert time.now == 15
             assert activity.status == ActivityState.SUCCESS
 
@@ -54,9 +54,9 @@ class TestDo:
         async with Scope() as scope:
             activity_one = scope.do(payload(10), at=5)
             activity_two = scope.do(payload(15), at=5)
-            await (activity_one | activity_two)
+            await (activity_one.done | activity_two.done)
             assert time.now == 15
-            await (activity_one & activity_two)
+            await (activity_one.done & activity_two.done)
             assert time.now == 20
 
     @via_usim
@@ -68,7 +68,7 @@ class TestDo:
         async with Scope() as scope:
             activity = scope.do(payload(), volatile=True)
         with pytest.raises(VolatileActivityExit):
-            assert await activity.result
+            assert await activity
         assert activity.status == ActivityState.FAILED
 
     @via_usim
@@ -154,7 +154,7 @@ async def test_until():
 
     assert time.now == 500
     with pytest.raises(ActivityCancelled):
-        await activity.result
+        await activity
 
 
 @via_usim
@@ -164,7 +164,7 @@ async def test_result():
         async with Scope() as scope:
             running_job = scope.do(run_job())
             running_job.cancel()
-            await running_job.result
+            await running_job
 
     async def run_job():
         await (time + 100)
@@ -180,7 +180,7 @@ async def test_reuse():
         async with Scope() as scope:
             running_job = scope.do(run_job())
             running_job.cancel()
-            await running_job
+            await running_job.done
 
     async def run_job():
         await (time + 100)

--- a/usim_pytest/test_types/test_activity.py
+++ b/usim_pytest/test_types/test_activity.py
@@ -1,4 +1,4 @@
-from usim import time, Scope, ActivityState, instant
+from usim import time, Scope, TaskState, instant
 
 from ..utility import via_usim
 
@@ -38,40 +38,40 @@ class TestExecution:
     async def test_state_success(self):
         async with Scope() as scope:
             activity = scope.do(sleep(20))
-            assert activity.status == ActivityState.CREATED
+            assert activity.status == TaskState.CREATED
             await instant
-            assert activity.status == ActivityState.RUNNING
+            assert activity.status == TaskState.RUNNING
             await activity.done
-            assert activity.status == ActivityState.SUCCESS
-            assert activity.status & ActivityState.FINISHED
+            assert activity.status == TaskState.SUCCESS
+            assert activity.status & TaskState.FINISHED
 
     @via_usim
     async def test_state_cancel_created(self):
         async with Scope() as scope:
             activity = scope.do(sleep(20))
-            assert activity.status == ActivityState.CREATED
+            assert activity.status == TaskState.CREATED
             activity.cancel()
             # early cancellation does not run
-            assert activity.status == ActivityState.CANCELLED
+            assert activity.status == TaskState.CANCELLED
             await instant
-            assert activity.status == ActivityState.CANCELLED
+            assert activity.status == TaskState.CANCELLED
             await activity.done
-            assert activity.status == ActivityState.CANCELLED
-            assert activity.status & ActivityState.FINISHED
+            assert activity.status == TaskState.CANCELLED
+            assert activity.status & TaskState.FINISHED
 
     @via_usim
     async def test_state_cancel_running(self):
         async with Scope() as scope:
             activity = scope.do(sleep(20))
-            assert activity.status == ActivityState.CREATED
+            assert activity.status == TaskState.CREATED
             await instant
-            assert activity.status == ActivityState.RUNNING
+            assert activity.status == TaskState.RUNNING
             activity.cancel()
             # running cancellation is graceful
-            assert activity.status == ActivityState.RUNNING
+            assert activity.status == TaskState.RUNNING
             await activity.done
-            assert activity.status == ActivityState.CANCELLED
-            assert activity.status & ActivityState.FINISHED
+            assert activity.status == TaskState.CANCELLED
+            assert activity.status & TaskState.FINISHED
 
     @via_usim
     async def test_condition(self):


### PR DESCRIPTION
Changed the API of rich ``Activity`` class to be similar to "bare" activities (aka coroutines).

```
await activity  # await bare activity

async with Scope() as scope:
    await scope.do(activity) # construct and await rich activity
```

Key changes invert how to query and wait for completion:

* ``await activity.result`` => ``await activity`` returns the result (value or exception) on completion
* ``await activity`` => ``await acitvity.done`` delays until completion