### PR TITLE
Condition chain

### DIFF
--- a/usim/_primitives/condition.py
+++ b/usim/_primitives/condition.py
@@ -102,10 +102,10 @@ class Connective(Condition):
         super().__init__()
         self._children = conditions
 
-    def __await__(self):
+    def __await__(self) -> bool:
         return (yield from self.__await_children__().__await__())
 
-    async def __await_children__(self):
+    async def __await_children__(self) -> bool:
         await postpone()
         while not self:
             with ExitStack() as stack:

--- a/usim/_primitives/condition.py
+++ b/usim/_primitives/condition.py
@@ -103,7 +103,7 @@ class Connective(Condition):
         self._children = conditions
 
     def __await__(self) -> bool:
-        return (yield from self.__await_children__().__await__())
+        return (yield from self.__await_children__().__await__())  # noqa: B901
 
     async def __await_children__(self) -> bool:
         await postpone()

--- a/usim/_primitives/condition.py
+++ b/usim/_primitives/condition.py
@@ -88,6 +88,11 @@ class Condition(Notification):
         else:
             super().__subscribe__(waiter, interrupt)
 
+    def __repr__(self):
+        return '<%s, bool=%s, waiters=%d>' % (
+            self.__class__.__name__, bool(self), len(self._waiting)
+        )
+
 
 class Connective(Condition):
     """Logical connection of sub-conditions"""

--- a/usim/_primitives/condition.py
+++ b/usim/_primitives/condition.py
@@ -36,11 +36,11 @@ class Condition(Notification):
 
     Every :py:class:`~.Condition` supports the bitwise operators
     ``~a`` (not),
-    ``a & b`` (and), and
+    ``a & b`` (and), as well as
     ``a | b`` (or)
     to derive a new :py:class:`~.Condition`.
     While it is possible to use the boolean operators
-    ``not``, ``and``, and ``or``,
+    ``not``, ``and``, as well as ``or``,
     they immediately evaluate any :py:class:`~.Condition` in a boolean context.
 
     .. code:: python

--- a/usim/_primitives/condition.py
+++ b/usim/_primitives/condition.py
@@ -103,7 +103,7 @@ class Connective(Condition):
         self._children = conditions
 
     def __await__(self):
-        yield from self.__await_children__().__await__()
+        return (yield from self.__await_children__().__await__())
 
     async def __await_children__(self):
         await postpone()

--- a/usim/_primitives/task.py
+++ b/usim/_primitives/task.py
@@ -197,7 +197,7 @@ class Task(Awaitable[RT]):
     def __repr__(self):
         return '<%s of %s (%s)>' % (
             self.__class__.__name__, self.payload,
-            'outstanding' if not self else (
+            'outstanding' if self._result is None else (
                 'result={!r}'.format(self._result[0])
                 if self._result[1] is None
                 else

--- a/usim_pytest/test_types/test_condition.py
+++ b/usim_pytest/test_types/test_condition.py
@@ -1,24 +1,29 @@
-from usim import Scope, Flag
+from usim import Flag
 
 from ..utility import via_usim
 
 
-class TestCondition:
+class TestChainedCondition:
     @via_usim
     async def test_chain_and(self):
         a, b, c = Flag(), Flag(), Flag()
         assert not a and not b and not c
         and_chain = a & b & c
         assert not and_chain
-        async with Scope() as scope:
-            wait_chain = scope.do(and_chain)
-            await a.set()
-            assert not and_chain
-            await b.set()
-            assert not and_chain
-            await c.set()
-            assert and_chain
-            await wait_chain
+        assert ~and_chain
+        assert await (~and_chain)
+        await a.set()
+        assert not and_chain
+        assert ~and_chain
+        assert await (~and_chain)
+        await b.set()
+        assert not and_chain
+        assert ~and_chain
+        assert await (~and_chain)
+        await c.set()
+        assert and_chain
+        assert not ~and_chain
+        assert await and_chain
 
     @via_usim
     async def test_chain_or(self):
@@ -26,12 +31,37 @@ class TestCondition:
         assert not a or not b or not c
         or_chain = a | b | c
         assert not or_chain
-        async with Scope() as scope:
-            wait_chain = scope.do(or_chain)
-            await a.set()
-            assert or_chain
-            await b.set()
-            assert or_chain
-            await c.set()
-            assert or_chain
-            await wait_chain
+        assert ~or_chain
+        assert await (~or_chain)
+        await a.set()
+        assert or_chain
+        assert not ~or_chain
+        assert await or_chain
+        await b.set()
+        assert or_chain
+        assert not ~or_chain
+        assert await or_chain
+        await c.set()
+        assert or_chain
+        assert not ~or_chain
+        assert await or_chain
+
+    @via_usim
+    async def test_chain_long(self):
+        a, b, c, d, e, f = Flag(), Flag(), Flag(), Flag(), Flag(), Flag()
+        chain = a & (b & c) & d | (e | f)
+        assert not chain
+        assert ~chain
+        assert await (~chain)
+        await d.set()
+        assert not chain
+        assert ~chain
+        assert await (~chain)
+        await c.set()
+        assert not chain
+        assert ~chain
+        assert await (~chain)
+        await e.set()
+        assert chain
+        assert not ~chain
+        assert await chain

--- a/usim_pytest/test_types/test_condition.py
+++ b/usim_pytest/test_types/test_condition.py
@@ -1,0 +1,37 @@
+from usim import Scope, Flag
+
+from ..utility import via_usim
+
+
+class TestCondition:
+    @via_usim
+    async def test_chain_and(self):
+        a, b, c = Flag(), Flag(), Flag()
+        assert not a and not b and not c
+        and_chain = a & b & c
+        assert not and_chain
+        async with Scope() as scope:
+            wait_chain = scope.do(and_chain)
+            await a.set()
+            assert not and_chain
+            await b.set()
+            assert not and_chain
+            await c.set()
+            assert and_chain
+            await wait_chain
+
+    @via_usim
+    async def test_chain_or(self):
+        a, b, c = Flag(), Flag(), Flag()
+        assert not a or not b or not c
+        or_chain = a | b | c
+        assert not or_chain
+        async with Scope() as scope:
+            wait_chain = scope.do(or_chain)
+            await a.set()
+            assert or_chain
+            await b.set()
+            assert or_chain
+            await c.set()
+            assert or_chain
+            await wait_chain


### PR DESCRIPTION
Fixes a bug as documented in issue #5.

Given the conditions ``a``, ``b``, ``c``, it was previously only well-defined to combine two with the same operand. It is now possible to combine an arbitrary number of conditions.

```python3
a | b & c  # worked
a & b | c  # worked
a | b | c  # fixed
a & b & c  # fixed
```

The pull request includes
* the bugfix itself,
* several unit-tests to replicate the issue,
* a slight rewording of the documentation,
* a bugfix for ``Task.__repr__`` that would cause the unit-test to abort in case of failure.