### PR TITLE
Scope Exceptions and Task Ownership

### DIFF
--- a/docs/source/topics/exceptions.rst
+++ b/docs/source/topics/exceptions.rst
@@ -1,0 +1,173 @@
+Concurrent Activities and Exceptions
+====================================
+
+In complex simulations, it is inevitable that things go wrong sometimes
+- in some cases, failure is even an expected part of the simulation itself.
+This makes it important to make failures explicit,
+but also to have tools to handle them.
+
+μSim extends the normal Python Exception model with two additions:
+A :py:class:`~usim.Scope` can perform multiple actions at once,
+and thus may encounter several failures at once.
+Similarly, several :py:exc:`~usim.Concurrent` exceptions may need to
+be handled individually or all at once.
+
+Scopes and Exceptions
+---------------------
+
+The purpose of a :py:class:`~usim.Scope` is to :py:meth:`~usim.Scope.do`
+additional activities concurrently, alongside a main activity represented
+by the Scope body itself.
+Consequently, we can separate exceptions into synchronous exceptions in the body,
+or :py:exc:`~usim.Concurrent` exceptions in a child activity.
+
+.. code:: python3
+
+    async def araise(what: BaseException):
+        raise what
+
+    async def scope_exception_demo():
+        """Demo that randomly fails in the body or child of a Scope"""
+        async with Scope() as scope:
+            delay = random.random()
+            scope.do(
+                araise(RuntimeError('child')),  # A: concurrent exception
+                after=delay
+            )
+            await (time + 1 - delay)
+            raise RuntimeError('body')          # B: synchronous exception
+
+Any exception that happens synchronously in the body is a failure of the
+:py:class:`~usim.Scope` itself.
+In the example, the ``RuntimeError('body')`` will teardown the scope and
+then propagate onwards.
+
+Any exception that happens concurrently in a child is a failure of the
+payloads, not the :py:class:`~usim.Scope`.
+In the example, the ``RuntimeError('child')`` will cause the
+:py:class:`~usim.Scope` to shut down and re-raise the exception as a
+``Concurrent(RuntimeError('child'))``.
+
+Handling Scope Exceptions
+-------------------------
+
+The :py:exc:`~usim.Concurrent` exception model is made to integrate with
+Python's regular ``try``/``except`` exception handling machinery.
+Synchronous exceptions do not need any extra effort to handle,
+while :py:exc:`~usim.Concurrent` exceptions have the required, additional
+error handling built in.
+To handle a :py:exc:`~usim.Concurrent` exception of a specific type,
+use ``except Concurrent[ExceptionType]`` instead of ``except ExceptionType``:
+
+.. code:: python3
+
+    async def handle_exception_demo()
+        """Demo for handling concurrent/synchronous exceptions"""
+        try:
+            await scope_exception_demo()
+        except RuntimeError as err:
+            print('Handled synchronous exception:', err)
+        except Concurrent[RuntimeError] as err:
+            print('Handled concurrent exception:', err)
+
+μSim guarantees that you never have to handle both a regular and
+:py:exc:`~usim.Concurrent` exception at the same time - it is an "either or" situation.
+Consequently, you can safely use separate error handlers for either exception flavour.
+:py:exc:`~usim.Concurrent` exceptions follow the regular subclassing relations
+of exceptions -- for example, ``Concurrent[LookupError]`` matches both
+``Concurrent[KeyError]`` and ``Concurrent[IndexError]``.
+
+.. note::
+
+    μSim considers the use of a :py:class:`~usim.Scope` an implementation detail of
+    functions and abstractions that should *not* be visible to users.
+    Consequently, we handle any :py:exc:`~usim.Concurrent` exceptions internally
+    and only propagate regular exceptions.
+    While this is not enforced for custom functions and abstractions,
+    we strongly recommend to adhere to this convention.
+
+Concurrency Privileges
+^^^^^^^^^^^^^^^^^^^^^^
+
+μSim itself is a highly concurrent, exception driven library.
+This means that certain exceptions must propagate unobstructed,
+while others are suppressed at well-defined points.
+In order not to require users to manually adhere to such unwritten rules,
+μSim has a concept for exception privileges in concurrent situations.
+
+Task local exceptions
+    Python's :py:exc:`GeneratorExit` and μSim's internal ``Interrupt``
+    represent the teardown of a Task or parts of it.
+    In the Task they are meant for, these exceptions will replace all
+    other synchronous or concurrent exceptions; otherwise, they are suppressed.
+    As a result, you do not have to worry about re-raising an ``Interrupt`` and
+    you should never encounter a ``Concurrent[GeneratorExit]``, for example.
+
+Application global exceptions
+    Python's :py:exc:`SystemExit`, :py:exc:`KeyboardInterrupt`, and
+    :py:exc:`AssertionError` [#debug]_ represent the teardown of the entire simulation.
+    These exceptions supersede any synchronous and concurrent exceptions,
+    and are always propagated as regular, synchronous exceptions.
+
+As a result, μSim will do the correct thing by default.
+You only have to worry about μSim's internal exceptions if you use catch-all
+exceptions handlers such as ``except BaseException:`` or even ``except:``.
+When you are unsure, ``raise`` at the end of a handler the let exceptions propagate.
+
+Handling Multiple Exceptions
+----------------------------
+
+Concurrency means that *several* child tasks may fail at the same :term:`time`.
+As a result, a :py:exc:`~usim.Concurrent` exception may contain several failures
+at once.
+
+.. code:: python3
+
+    async def multi_exception_demo():
+        """Demo that fails in multiple children of a Scope"""
+        async with Scope() as scope:
+            scope.do(araise(IndexError('A')))    # A
+            scope.do(araise(KeyError('B')))      # B
+            scope.do(araise(IndexError('C')))    # C
+            await (time + 2)                     # async exceptions arrive here
+            scope.do(araise(KeyError('D')))      # D
+
+This example will propagate a single exception :py:exc:`~usim.Concurrent` exception
+containing ``IndexError('A')``, ``KeyError('B')``, and ``IndexError('C')`` --
+the ``KeyError('D')`` is suppressed by the scope stopping itself and its children.
+The *type* of the exception includes all the types of its child exceptions,
+namely ``Concurrent[IndexError, KeyError]``.
+Note that neither the *number* nor *order* of exceptions is captured in the type.
+
+Use ``[]`` to specialise precisely which concurrent failure you want to handle.
+Multiple subtypes represent an "and" relation -- ``Concurrent[X, Y]`` requires
+both ``X`` and ``Y`` exceptions to be thrown at the same time.
+Including a literal ``...`` means that additional subtypes are allowed --
+``Concurrent[X, Y, ...]`` matches both ``X`` and ``Y`` plus zero or more others.
+Use ``Concurrent[...]`` to handle any concurrent exception.
+
+.. code:: python3
+
+    try:
+        await some_failure()
+    except X:
+        print('Handled a synchronous X exception')
+    except Y, Concurrent[Y]:
+        print('Handled a synchronous or concurrent Y exception')
+    except Concurrent[X, Z]:
+        print('Handled a concurrent X and Z exception')
+    except Concurrent[X], Concurrent[Z]:
+        print('Handled a concurrent X or a concurrent Z exception')
+
+As with exception handling in general, avoid too broad exception cases.
+Prefer specific exceptions over general ones,
+e.g. ``Concurrent[KeyError]`` over ``Concurrent[LookupError]``
+or even ``Concurrent[Exception]``.
+If possible, use exact exception subtypes over open ones,
+e.g. ``Concurrent[KeyError, RuntimeError]`` instead of ``Concurrent[KeyError, ...]``.
+Finally, we recommend using ``Concurrent[...]`` only if you want to suppress
+concurrent exceptions unconditionally.
+
+
+.. [#debug] For the use of :py:exc:`AssertionError` by μSim,
+            see also :doc:`./debug`.

--- a/docs/source/topics/exceptions.rst
+++ b/docs/source/topics/exceptions.rst
@@ -12,8 +12,8 @@ and thus may encounter several failures at once.
 Similarly, several :py:exc:`~usim.Concurrent` exceptions may need to
 be handled individually or all at once.
 
-Scopes and Exceptions
----------------------
+Concurrency and Exceptions
+--------------------------
 
 The purpose of a :py:class:`~usim.Scope` is to :py:meth:`~usim.Scope.do`
 activities concurrently, alongside a main activity represented
@@ -48,8 +48,8 @@ In the example, the ``RuntimeError('child')`` will cause the
 :py:class:`~usim.Scope` to shut down and re-raise the exception as a
 ``Concurrent(RuntimeError('child'))``.
 
-Handling Scope Exceptions
--------------------------
+Handling Concurrent Exceptions
+------------------------------
 
 The :py:exc:`~usim.Concurrent` exception model is made to integrate with
 Python's regular ``try``/``except`` exception handling machinery.

--- a/docs/source/topics/exceptions.rst
+++ b/docs/source/topics/exceptions.rst
@@ -16,7 +16,7 @@ Scopes and Exceptions
 ---------------------
 
 The purpose of a :py:class:`~usim.Scope` is to :py:meth:`~usim.Scope.do`
-additional activities concurrently, alongside a main activity represented
+activities concurrently, alongside a main activity represented
 by the Scope body itself.
 Consequently, we can separate exceptions into synchronous exceptions in the body,
 or :py:exc:`~usim.Concurrent` exceptions in a child activity.
@@ -53,8 +53,8 @@ Handling Scope Exceptions
 
 The :py:exc:`~usim.Concurrent` exception model is made to integrate with
 Python's regular ``try``/``except`` exception handling machinery.
-Synchronous exceptions do not need any extra effort to handle,
-while :py:exc:`~usim.Concurrent` exceptions have the required, additional
+Synchronous exceptions do not need any extra effort to handle.
+The :py:exc:`~usim.Concurrent` exceptions have the required, additional
 error handling built in.
 To handle a :py:exc:`~usim.Concurrent` exception of a specific type,
 use ``except Concurrent[ExceptionType]`` instead of ``except ExceptionType``:
@@ -70,7 +70,7 @@ use ``except Concurrent[ExceptionType]`` instead of ``except ExceptionType``:
         except Concurrent[RuntimeError] as err:
             print('Handled concurrent exception:', err)
 
-μSim guarantees that you never have to handle both a regular and
+μSim guarantees that you never have to handle both a regular and a
 :py:exc:`~usim.Concurrent` exception at the same time - it is an "either or" situation.
 Consequently, you can safely use separate error handlers for either exception flavour.
 :py:exc:`~usim.Concurrent` exceptions follow the regular subclassing relations
@@ -81,7 +81,7 @@ of exceptions -- for example, ``Concurrent[LookupError]`` matches both
 
     μSim considers the use of a :py:class:`~usim.Scope` an implementation detail of
     functions and abstractions that should *not* be visible to users.
-    Consequently, we handle any :py:exc:`~usim.Concurrent` exceptions internally
+    Consequently, we handle any :py:exc:`~usim.Concurrent` exception internally
     and only propagate regular exceptions.
     While this is not enforced for custom functions and abstractions,
     we strongly recommend to adhere to this convention.
@@ -98,7 +98,7 @@ In order not to require users to manually adhere to such unwritten rules,
 Task local exceptions
     Python's :py:exc:`GeneratorExit` and μSim's internal ``Interrupt``
     represent the teardown of a Task or parts of it.
-    In the Task they are meant for, these exceptions will replace all
+    In the Task they belong to, these exceptions will replace all
     other synchronous or concurrent exceptions; otherwise, they are suppressed.
     As a result, you do not have to worry about re-raising an ``Interrupt`` and
     you should never encounter a ``Concurrent[GeneratorExit]``, for example.
@@ -111,8 +111,8 @@ Application global exceptions
 
 As a result, μSim will do the correct thing by default.
 You only have to worry about μSim's internal exceptions if you use catch-all
-exceptions handlers such as ``except BaseException:`` or even ``except:``.
-When you are unsure, ``raise`` at the end of a handler the let exceptions propagate.
+exception handlers such as ``except BaseException:`` or even ``except:``.
+In case you are unsure, ``raise`` at the end of a handler to let exceptions propagate.
 
 Handling Multiple Exceptions
 ----------------------------
@@ -135,7 +135,7 @@ at once.
 This example will propagate a single exception :py:exc:`~usim.Concurrent` exception
 containing ``IndexError('A')``, ``KeyError('B')``, and ``IndexError('C')`` --
 the ``KeyError('D')`` is suppressed by the scope stopping itself and its children.
-The *type* of the exception includes all the types of its child exceptions,
+The *type* of the exception includes all types of its child exceptions,
 namely ``Concurrent[IndexError, KeyError]``.
 Note that neither the *number* nor *order* of exceptions is captured in the type.
 

--- a/docs/source/topics/overview.rst
+++ b/docs/source/topics/overview.rst
@@ -6,4 +6,5 @@ This is a collection of separate topics on μSim.
 .. toctree::
     :maxdepth: 1
 
+    exceptions
     debug

--- a/usim/__init__.py
+++ b/usim/__init__.py
@@ -5,7 +5,7 @@ from ._core.loop import Loop as _Loop
 from ._primitives.timing import Time, Eternity, Instant, each
 from ._primitives.flag import Flag
 from ._primitives.locks import Lock
-from ._primitives.context import until, Scope, VolatileTaskExit
+from ._primitives.context import until, Scope, VolatileTaskClosed
 from ._primitives.task import TaskCancelled, TaskState
 from ._primitives.concurrent_exception import Concurrent
 
@@ -13,7 +13,7 @@ from ._primitives.concurrent_exception import Concurrent
 __all__ = [
     'run',
     'time', 'eternity', 'instant', 'each',
-    'until', 'Scope', 'TaskCancelled', 'VolatileTaskExit', 'TaskState',
+    'until', 'Scope', 'TaskCancelled', 'VolatileTaskClosed', 'TaskState',
     'Flag', 'Lock',
     'Concurrent',
 ]

--- a/usim/__init__.py
+++ b/usim/__init__.py
@@ -6,14 +6,14 @@ from ._primitives.timing import Time, Eternity, Instant, each
 from ._primitives.flag import Flag
 from ._primitives.locks import Lock
 from ._primitives.context import until, Scope, VolatileTaskClosed
-from ._primitives.task import TaskCancelled, TaskState
+from ._primitives.task import TaskCancelled, TaskState, TaskClosed
 from ._primitives.concurrent_exception import Concurrent
 
 
 __all__ = [
     'run',
     'time', 'eternity', 'instant', 'each',
-    'until', 'Scope', 'TaskCancelled', 'VolatileTaskClosed', 'TaskState',
+    'until', 'Scope', 'TaskCancelled', 'VolatileTaskClosed', 'TaskClosed', 'TaskState',
     'Flag', 'Lock',
     'Concurrent',
 ]

--- a/usim/__init__.py
+++ b/usim/__init__.py
@@ -7,6 +7,7 @@ from ._primitives.flag import Flag
 from ._primitives.locks import Lock
 from ._primitives.context import until, Scope, VolatileTaskExit
 from ._primitives.task import TaskCancelled, TaskState
+from ._primitives.concurrent_exception import Concurrent
 
 
 __all__ = [
@@ -14,6 +15,7 @@ __all__ = [
     'time', 'eternity', 'instant', 'each',
     'until', 'Scope', 'TaskCancelled', 'VolatileTaskExit', 'TaskState',
     'Flag', 'Lock',
+    'Concurrent',
 ]
 
 

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -183,9 +183,13 @@ class Concurrent(Exception, metaclass=MetaConcurrent):
     __specialisations__ = WeakValueDictionary()
 
     def __new__(cls: 'Type[Concurrent]', *children):
-        if not children:
-            assert cls.specialisations is None, 'specialisation must match children'
+        if children is None:
+            assert cls.specialisations is None,\
+                f"specialisation () does not match children {children}"
             return super().__new__(cls)
+        assert children,\
+            f'specialised {cls.__name__} must receive matching children\n'\
+            f'instantiate the unspecialised type {cls.template.__name__!r} instead'
         specialisations = frozenset(type(child) for child in children)
         try:
             special_cls = cls.__specialisations__[children]

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -147,6 +147,7 @@ class Concurrent(Exception, metaclass=MetaConcurrent):
 
     """
     def __init__(self, *children):
+        super().__init__(children)
         self.children = children
 
     def __str__(self):

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -1,0 +1,156 @@
+from typing import Optional, Tuple, Union, Type, Dict, Any
+
+
+class MetaConcurrent(type):
+    def __new__(
+            mcs,
+            name: str,
+            bases: Tuple[Type, ...],
+            namespace: Dict[str, Any],
+            specialisations: Optional[Tuple[Union[Type[Exception], 'ellipsis'], ...]] = None,
+            **kwargs,
+    ):
+        cls = super().__new__(mcs, name, bases, namespace, **kwargs)  # type: MetaConcurrent
+        if specialisations is not None:
+            try:
+                i = specialisations.index(...)
+            except ValueError:
+                cls.inclusive = False
+            else:
+                cls.inclusive = True
+                specialisations = specialisations[:i] + specialisations[i+1:]
+                assert ... not in specialisations,\
+                    "only one ... allowed in specialisations"
+        else:
+            cls.inclusive = True
+        cls.specialisations = specialisations
+        return cls
+
+    def __instancecheck__(cls, instance):
+        if type(instance) == Concurrent:
+            # except MultiError:
+            if cls.specialisations is None:
+                return True
+            # except MultiError[]:
+            else:
+                return cls._instancecheck_specialisation(instance)
+        return False
+
+    def _instancecheck_specialisation(cls, instance: 'Concurrent'):
+        matched_specialisations = sum(
+            1 for specialisation in cls.specialisations
+            if any(
+                isinstance(child, specialisation)
+                for child in instance.children
+            )
+        )
+        if matched_specialisations < len(cls.specialisations):
+            return False
+        # except MultiError[KeyError, ...]
+        elif cls.inclusive:
+            return True
+        # except MultiError[KeyError]:
+        else:
+            return not any(
+                not isinstance(child, cls.specialisations)
+                for child in instance.children
+            )
+
+    def __getitem__(cls, item: Union[Type[Exception], 'ellipsis', Tuple[Union[Type[Exception], 'ellipsis'], ...]]):
+        if cls.specialisations is not None:
+            raise TypeError(f'Cannot specialise already specialised {cls.__name__!r}')
+        if not isinstance(item, tuple):
+            if item is ...:
+                return cls
+            assert issubclass(item, Exception),\
+                f'{cls.__name__!r} may only be specialised by Exception subclasses'
+            name = f'{cls.__name__}[{item.__name__}]'
+            return MetaConcurrent(name, (cls,), {}, specialisations=(item,))
+        else:
+            assert all(
+                issubclass(child, Exception) or (child is ...) for child in item
+            ),\
+                f'{cls.__name__!r} may only be specialised by Exception subclasses'
+            name = f'{cls.__name__}[{", ".join(child.__name__ for child in item)}]'
+            return MetaConcurrent(name, (cls,), {}, specialisations=tuple(set(item)))
+
+
+class Concurrent(Exception, metaclass=MetaConcurrent):
+    """
+    Exception from one or more concurrent :term:`activity`
+
+    A meta-exception that represents any :py:exc:`Exception` of any failing
+    :py:class:`~usim.typing.Task` of a :py:class:`~usim.Scope`. This does not
+    include any :py:exc:`Exception` thrown in the body of the scope. As a result,
+    it is possible to separately catch concurrent and regular exceptions:
+
+    .. code:: python3
+
+        try:
+            async with Scope() as scope:
+                if random.random() < 0.5:
+                    scope.do(
+                        async_raise(RuntimeError('concurrent'))
+                    )
+                else:
+                    raise RuntimeError('scoped')
+        except RuntimeError:
+            print('Failed in body')
+        except Concurrent:
+            print('Failed in child')
+
+    In addition to separating concurrent and regular exceptions,
+    :py:class:`~.Concurrent` can also separate different concurrent exception types.
+    Subscribing the :py:class:`~.Concurrent` type as ``Concurrent[Exception]``
+    specialise ``except`` clauses to a specific concurrent :py:exc:`Exception`:
+
+    .. code:: python3
+
+        try:
+            async with Scope() as scope:
+                if random.random() < 0.333:
+                    scope.do(async_raise(KeyError('concurrent')))
+                elif random.random() < 0.5:
+                    scope.do(async_raise(IndexError('concurrent')))
+                else:
+                    scope.do(async_raise(ValueError('concurrent')))
+        except Concurrent[KeyError]:
+            print('Failed key lookup')
+        except Concurrent[IndexError]:
+            print('Failed indexing')
+        except (Concurrent[TypeError], Concurrent[ValueError]):
+            print('Incorrect type/value of something!')
+
+    Since a :py:class:`~usim.Scope` can run more than one :py:class:`~usim.typing.Task`
+    concurrently, there can be more than one failure as well. Subscribing
+    :py:class:`~.Concurrent` is possible for several types at once:
+    ``Concurrent[ExceptionA, ExceptionB]`` matches only ``ExceptionA`` and
+    ``ExceptionB`` at the same time, and
+    ``Concurrent[ExceptionA, ExceptionB, ...]`` matches at least ``ExceptionA`` and
+    ``ExceptionB`` at the same time.
+
+    .. code:: python3
+
+        try:
+            async with Scope() as scope:
+                scope.do(async_raise(KeyError('concurrent')))
+                if random.random() < 0.5:
+                    scope.do(async_raise(IndexError('concurrent')))
+                if random.random() < 0.5:
+                    scope.do(async_raise(ValueError('concurrent')))
+        except Concurrent[KeyError]:
+            print('Failed only key lookup')
+        except Concurrent[KeyError, IndexError]:
+            print('Failed key lookup and indexing')
+        except Concurrent[KeyError, ...]:
+            print('Failed key lookup and something else')
+
+    """
+    def __init__(self, *children):
+        self.children = children
+
+    def __str__(self):
+        return ', '.join(map(repr, self.children))
+
+    def __repr__(self):
+        return f'<usim.f{self.__class__.__name__} of {self}>'

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -100,14 +100,13 @@ class MetaConcurrent(type):
         # This means that we must handle cases where specialisations
         # match multiple times - for example, when matching
         # Class[B] against Class[A, B], then B matches both A and B,
-        matched_specialisations = sum(
-            1 for specialisation in cls.specialisations
-            if any(
+        matched_specialisations = all(
+            any(
                 issubclass(child, specialisation)
                 for child in subclass.specialisations
-            )
+            ) for specialisation in cls.specialisations
         )
-        if matched_specialisations < len(cls.specialisations):
+        if not matched_specialisations:
             return False
         # except MultiError[KeyError, ...]
         elif cls.inclusive:

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -168,6 +168,10 @@ class Concurrent(Exception, metaclass=MetaConcurrent):
             print('Failed key lookup and something else')
 
     """
+    def __new__(cls: 'Type[Concurrent]', *children):
+        specialisation = cls[tuple(type(child) for child in children)]
+        return super().__new__(specialisation, *children)
+
     def __init__(self, *children):
         super().__init__(children)
         self.children = children

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -26,6 +26,17 @@ class MetaConcurrent(type):
         cls.specialisations = specialisations
         return cls
 
+    # Implementation Note:
+    # The Python data model defines both
+    # * ``isinstance(a, b) => type(b).__instancecheck__(b, a)``
+    # * ``issubclass(a, b) => type(b).__subclasscheck__(b, a)``
+    # So we could need either for error handling.
+    #
+    # The Python language translates the except clause of
+    #   try: raise a
+    #   except b as err: <block>
+    # to ``if issubclass(type(a), b): <block>``.
+    # Which means we need ``__subclasscheck__`` only.
     def __instancecheck__(cls, instance):
         if type(instance) == Concurrent:
             # except MultiError:
@@ -35,6 +46,9 @@ class MetaConcurrent(type):
             else:
                 return cls._instancecheck_specialisation(instance)
         return False
+
+    def __subclasscheck__(cls, subclass):
+        return super().__subclasscheck__(subclass)
 
     def _instancecheck_specialisation(cls, instance: 'Concurrent'):
         matched_specialisations = sum(

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -135,7 +135,7 @@ class MetaConcurrent(type):
         return f"<class 'usim.{cls.__name__}'>"
 
 
-class Concurrent(Exception, metaclass=MetaConcurrent):
+class Concurrent(BaseException, metaclass=MetaConcurrent):
     """
     Exception from one or more concurrent :term:`activity`
 

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -15,16 +15,17 @@ class MetaConcurrent(type):
             try:
                 i = specialisations.index(...)
             except ValueError:
-                cls.inclusive = False
+                inclusive = False
             else:
-                cls.inclusive = True
+                inclusive = True
                 specialisations = specialisations[:i] + specialisations[i+1:]
                 assert ... not in specialisations,\
                     "only one ... allowed in specialisations"
             template = bases[0]
         else:
-            cls.inclusive = True
+            inclusive = True
             template = cls
+        cls.inclusive = inclusive
         cls.specialisations = specialisations
         cls.template = template
         return cls

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -100,6 +100,8 @@ class MetaConcurrent(type):
         # This means that we must handle cases where specialisations
         # match multiple times - for example, when matching
         # Class[B] against Class[A, B], then B matches both A and B,
+        #
+        # Make sure that ``cls`` has no unmatched specialisations
         matched_specialisations = all(
             any(
                 issubclass(child, specialisation)
@@ -115,6 +117,10 @@ class MetaConcurrent(type):
         # except MultiError[KeyError]:
         else:
             # Make sure that ``subclass`` has no unmatched specialisations
+            #
+            # We need to check every child of subclass instead of comparing counts.
+            # This is needed in case that we have duplicate matches. Consider:
+            # Concurrent[KeyError, LookupError], Concurrent[KeyError, RuntimeError]
             return not any(
                 not issubclass(child, cls.specialisations)
                 for child in subclass.specialisations

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -197,7 +197,7 @@ class Concurrent(BaseException, metaclass=MetaConcurrent):
             print('Incorrect type/value of something!')
 
     Since a :py:class:`~usim.Scope` can run more than one :py:class:`~usim.typing.Task`
-    concurrently, there can be more than one failure as well. Subscribing
+    concurrently, there can be more than one exception as well. Subscribing
     :py:class:`~.Concurrent` is possible for several types at once:
     ``Concurrent[ExceptionA, ExceptionB]`` matches only ``ExceptionA`` and
     ``ExceptionB`` at the same time, and

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -25,7 +25,7 @@ class MetaConcurrent(type):
     #   <namespace>
     #
     # __new__ is called once per type hierarchy when the template
-    # is defined usin `class ...`.
+    # is defined using `class ...`.
     # Afterwards, __getitem__ (i.e. Class[...]) explicitly calls
     # __new__ to create specialisations.
     def __new__(

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -58,6 +58,8 @@ class MetaConcurrent(type):
 
     def __subclasscheck__(cls, subclass):
         """``issubclass(subclass, cls)``"""
+        if cls is subclass:
+            return True
         try:
             template = subclass.template
         except AttributeError:

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -103,7 +103,8 @@ class MetaConcurrent(type):
                 Tuple[Union[Type[Exception], 'ellipsis'], ...]
             ]
     ):
-        """``cls[item]``"""
+        """``cls[item]`` - used to specialise ``cls`` with ``item``"""
+        # check parameters
         if cls.specialisations is not None:
             raise TypeError(f'Cannot specialise already specialised {cls.__name__!r}')
         if item is ...:
@@ -117,6 +118,7 @@ class MetaConcurrent(type):
                 (child is ...) or issubclass(child, Exception) for child in item
             ),\
                 f'{cls.__name__!r} may only be specialised by Exception subclasses'
+        # specialise class
         unique_spec = frozenset(item)
         try:
             specialised_cls = cls.__specialisations__[unique_spec]

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -147,6 +147,12 @@ class Scope:
         :py:class:`GeneratorExit` is raised in the activity,
         which must exit without ``await``\ ing or ``yield``\ ing anything.
         """
+        assert after is None or at is None,\
+            "schedule date must be either absolute or relative"
+        assert after is None or after > 0,\
+            "schedule date must not be in the past"
+        assert at is None or at > __LOOP_STATE__.LOOP.time,\
+            "schedule date must not be in the past"
         child_task = Task(payload, self, delay=after, at=at)
         __LOOP_STATE__.LOOP.schedule(
             child_task.__runner__,

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -178,9 +178,9 @@ class Scope:
         for child in self._children:
             if child.status is TaskState.FAILED:
                 exc = child.__exception__
-                if type(exc) in promote:
+                if isinstance(exc, promote):
                     privileged.append(exc)
-                if type(exc) not in suppress:
+                if not isinstance(exc, suppress):
                     concurrent.append(exc)
         if privileged:
             raise privileged[0]

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -218,7 +218,7 @@ class Scope:
         self._activity = __LOOP_STATE__.LOOP.activity
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
         if exc_type is None:
             try:
                 # inform everyone that we are shutting down
@@ -233,7 +233,7 @@ class Scope:
         # there was an exception, we have to abandon the scope
         return self._aexit_forceful(exc_type, exc_val)
 
-    def _aexit_forceful(self, exc_type, exc_val):
+    def _aexit_forceful(self, exc_type, exc_val) -> bool:
         """
         Exit with exception
 
@@ -255,9 +255,11 @@ class Scope:
             self._reraise_privileged()
         if self._is_suppressed(exc_val):
             self._reraise_concurrent()
-        return self._is_suppressed(exc_val)
+            return True
+        else:
+            return False
 
-    async def _aexit_graceful(self):
+    async def _aexit_graceful(self) -> bool:
         """
         Exit without exception
 
@@ -277,7 +279,7 @@ class Scope:
             self._disable_interrupts()
             self._close_volatile()
             self._reraise_concurrent()
-            return self._is_suppressed(None)
+            return True
 
     def _is_suppressed(self, exc_val) -> bool:
         """

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -261,7 +261,7 @@ class Scope:
         """
         Exit without exception
 
-        This suspends the scope until all children have finished by themselves.
+        This suspends the scope until all children have finished themselves.
         If any children encountered an error, they are reraised as
         :py:exc:`~.Concurrent` errors.
 

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -3,14 +3,14 @@ from typing import Coroutine, List, TypeVar, Any, Optional
 from .._core.loop import __LOOP_STATE__, Interrupt as CoreInterrupt
 from .notification import Notification
 from .flag import Flag
-from .task import Task, TaskExit, TaskState, TaskCancelled
+from .task import Task, TaskClosed, TaskState, TaskCancelled
 from .concurrent_exception import Concurrent
 
 
 RT = TypeVar('RT')
 
 
-class VolatileTaskExit(TaskExit):
+class VolatileTaskClosed(TaskClosed):
     """A volatile :py:class:`~.Task` forcefully exited at the end of its scope"""
 
 
@@ -85,7 +85,7 @@ class Scope:
 
     #: Exceptions which are *not* re-raised from concurrent tasks
     SUPPRESS_CONCURRENT = (
-        TaskCancelled, TaskExit, GeneratorExit
+        TaskCancelled, TaskClosed, GeneratorExit
     )
     #: Exceptions which are always propagated unwrapped
     PROMOTE_CONCURRENT = (
@@ -199,7 +199,7 @@ class Scope:
             child.cancel(self)
 
     def _close_volatile(self):
-        reason = VolatileTaskExit("closed at end of scope '%s'" % self)
+        reason = VolatileTaskClosed("closed at end of scope '%s'" % self)
         for child in self._volatile_children:
             child.__close__(reason=reason)
 

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -125,7 +125,7 @@ class Scope:
         :py:class:`GeneratorExit` is raised in the activity,
         which must exit without `await`\ ing or `yield`\ ing anything.
         """
-        child_task = Task(payload)
+        child_task = Task(payload, self)
         __LOOP_STATE__.LOOP.schedule(
             child_task.__runner__,
             delay=after, at=at

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -174,17 +174,15 @@ class Scope:
     async def _reraise_children(self):
         suppress = self.SUPPRESS_CONCURRENT
         promote = self.PROMOTE_CONCURRENT
-        concurrent, privileged = [], []
+        concurrent = []
         for child in self._children:
             if child.status is TaskState.FAILED:
                 exc = child.__exception__
                 if isinstance(exc, promote):
-                    privileged.append(exc)
+                    raise exc
                 if not isinstance(exc, suppress):
                     concurrent.append(exc)
-        if privileged:
-            raise privileged[0]
-        elif concurrent:
+        if concurrent:
             raise Concurrent(*concurrent)
 
     def _cancel_children(self):

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -155,6 +155,7 @@ class Scope:
 
     def _disable_interrupts(self):
         self._interruptable = False
+        self._cancel_self.revoke()
 
     async def _await_children(self):
         for child in self._children:

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -171,7 +171,7 @@ class Scope:
         for child in self._children:
             await child.done
 
-    async def _reraise_concurrent(self):
+    def _reraise_concurrent(self):
         """re-``raise`` any exceptions that occurred concurrently"""
         suppress = self.SUPPRESS_CONCURRENT
         promote = self.PROMOTE_CONCURRENT
@@ -186,7 +186,7 @@ class Scope:
         if concurrent:
             raise Concurrent(*concurrent)
 
-    async def _reraise_privileged(self):
+    def _reraise_privileged(self):
         """re-``raise`` any important exceptions that occurred concurrently"""
         promote = self.PROMOTE_CONCURRENT
         for child in self._children:
@@ -247,9 +247,9 @@ class Scope:
         self._close_volatile()
         # allow replacing our exception with more important ones
         if not issubclass(exc_type, self.PROMOTE_CONCURRENT):
-            await self._reraise_privileged()
+            self._reraise_privileged()
         if self._suppress_exception(exc_val):
-            await self._reraise_concurrent()
+            self._reraise_concurrent()
         return self._suppress_exception(exc_val)
 
     async def _aexit_graceful(self):
@@ -262,7 +262,7 @@ class Scope:
             self._close_volatile()
             # everybody is dead - we just handle the cleanup
             self._disable_interrupts()
-            await self._reraise_concurrent()
+            self._reraise_concurrent()
             return self._suppress_exception(None)
 
     def _handle_close(self, exc_val: GeneratorExit) -> bool:

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -147,10 +147,9 @@ class Scope:
         :py:class:`GeneratorExit` is raised in the activity,
         which must exit without ``await``\ ing or ``yield``\ ing anything.
         """
-        child_task = Task(payload, self)
+        child_task = Task(payload, self, delay=after, at=at)
         __LOOP_STATE__.LOOP.schedule(
             child_task.__runner__,
-            delay=after, at=at
         )
         if not volatile:
             self._children.append(child_task)

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -279,12 +279,6 @@ class Scope:
             self._reraise_concurrent()
             return self._is_suppressed(None)
 
-    def _handle_close(self, exc_val: GeneratorExit) -> bool:
-        assert isinstance(exc_val, GeneratorExit)
-        for child in self._children + self._volatile_children:
-            child.__close__()
-        return self._is_suppressed(exc_val)
-
     def _is_suppressed(self, exc_val) -> bool:
         """
         Whether the exception is handled completely by :py:meth:`~.__aexit__`

--- a/usim/_primitives/task.py
+++ b/usim/_primitives/task.py
@@ -93,7 +93,7 @@ class Task(Awaitable[RT]):
     :note: This class should not be instantiated directly.
            Always use a :py:class:`~.Scope` to create it.
     """
-    __slots__ = ('payload', '_result', '__runner__', '_cancellations', '_done', 'parent')
+    __slots__ = 'payload', '_result', '__runner__', '_cancellations', '_done', 'parent'
 
     def __init__(self, payload: Coroutine[Any, Any, RT], parent: 'Scope'):
         @wraps(payload)

--- a/usim/_primitives/task.py
+++ b/usim/_primitives/task.py
@@ -56,7 +56,7 @@ class CancelTask(Interrupt):
         return result
 
 
-class TaskExit(BaseException):
+class TaskClosed(Exception):
     """A :py:class:`~.Task` forcefully exited"""
 
 
@@ -172,7 +172,7 @@ class Task(Awaitable[RT]):
             if error is not None:
                 return (
                     TaskState.CANCELLED
-                    if isinstance(error, (TaskCancelled, TaskExit))
+                    if isinstance(error, (TaskCancelled, TaskClosed))
                     else TaskState.FAILED
                 )
             return TaskState.SUCCESS
@@ -181,7 +181,7 @@ class Task(Awaitable[RT]):
             return TaskState.CREATED
         return TaskState.RUNNING
 
-    def __close__(self, reason=TaskExit('activity closed')):
+    def __close__(self, reason=TaskClosed('activity closed')):
         """
         Close the underlying coroutine
 

--- a/usim/_primitives/task.py
+++ b/usim/_primitives/task.py
@@ -142,6 +142,13 @@ class Task(Awaitable[RT]):
             return result  # noqa: B901
 
     @property
+    def __exception__(self) -> Optional[BaseException]:
+        """Get the exception of this task"""
+        assert self._result is not None,\
+            f'Task.__exception__ may only be queried for finished tasks'
+        return self._result[1]
+
+    @property
     def done(self) -> 'Done':
         """
         :py:class:`~.Condition` whether the :py:class:`~.Task` has stopped running.

--- a/usim_pytest/test_scopes.py
+++ b/usim_pytest/test_scopes.py
@@ -1,7 +1,7 @@
 import pytest
 
 from usim import Scope, time, eternity, VolatileTaskClosed, TaskState,\
-    TaskCancelled, until, each
+    TaskCancelled, TaskClosed, until, each
 
 from .utility import via_usim, assertion_mode
 
@@ -41,8 +41,6 @@ class TestDo:
             activity = scope.do(payload(), after=5)
             assert activity.status == TaskState.CREATED
             await (time + 4)
-            assert activity.status == TaskState.CREATED
-            await (time + 3)
             assert activity.status == TaskState.RUNNING
             await activity.done
             assert time.now == 15
@@ -164,7 +162,7 @@ async def test_until():
         activity = running.do(scheduler())
 
     assert time.now == 500
-    with pytest.raises(TaskCancelled):
+    with pytest.raises(TaskClosed):
         await activity
 
 

--- a/usim_pytest/test_scopes.py
+++ b/usim_pytest/test_scopes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from usim import Scope, time, eternity, VolatileTaskExit, TaskState,\
+from usim import Scope, time, eternity, VolatileTaskClosed, TaskState,\
     TaskCancelled, until, each
 
 from .utility import via_usim, assertion_mode
@@ -69,7 +69,7 @@ class TestDo:
 
         async with Scope() as scope:
             activity = scope.do(payload(), volatile=True)
-        with pytest.raises(VolatileTaskExit):
+        with pytest.raises(VolatileTaskClosed):
             assert await activity
         assert activity.status == TaskState.CANCELLED
 

--- a/usim_pytest/test_tests.py
+++ b/usim_pytest/test_tests.py
@@ -31,7 +31,7 @@ class TestTests:
 
     @pytest.mark.xfail(raises=Concurrent[KeyError], strict=True)
     @via_usim
-    async def test_scoped(self):
+    async def test_concurrent_scoped(self):
         async with Scope() as scope:
             scope.do(a_raise(KeyError()))
 

--- a/usim_pytest/test_types/test_concurrent_exception.py
+++ b/usim_pytest/test_types/test_concurrent_exception.py
@@ -4,6 +4,7 @@ from usim import Concurrent
 
 
 class FakeConcurrent:
+    """Fake of ``Concurrent`` that offers some fields but is not a subclass"""
     template = BaseException
 
 
@@ -21,7 +22,7 @@ class TestConcurrent:
             raise Concurrent(KeyError(), IndexError())
 
     def test_specialised_single(self):
-        """Specialised ``Concurrent[a]`` catches only ``Concurrent(a())``"""
+        """``Concurrent[a]`` matches only ``Concurrent(a())``"""
         with pytest.raises(Concurrent[IndexError]):
             raise Concurrent(IndexError())
         with pytest.raises(Concurrent[KeyError]):
@@ -35,7 +36,7 @@ class TestConcurrent:
                 raise Concurrent(IndexError())
 
     def test_specialised_multi(self):
-        """Specialised ``Concurrent[a, b]`` catches only ``Concurrent(a(), b())``"""
+        """``Concurrent[a, b]`` matches only ``Concurrent(a(), b())``"""
         with pytest.raises(Concurrent[IndexError, KeyError]):
             raise Concurrent(IndexError(), KeyError())
         with pytest.raises(Concurrent[TypeError, ValueError]):
@@ -52,7 +53,7 @@ class TestConcurrent:
                     raise Concurrent(IndexError(), KeyError(), ValueError())
 
     def test_specialised_single_open(self):
-        """Specialised ``Concurrent[a, ...]`` catches any ``Concurrent(a(), ...)``"""
+        """``Concurrent[a, ...]`` matches any ``Concurrent(a(), ...)``"""
         with pytest.raises(Concurrent[IndexError, ...]):
             raise Concurrent(IndexError())
         with pytest.raises(Concurrent[IndexError, ...]):
@@ -68,7 +69,7 @@ class TestConcurrent:
                 raise Concurrent(IndexError(), ValueError())
 
     def test_specialised_multi_open(self):
-        """Specialised ``Concurrent[a, ...]`` catches any ``Concurrent(a(), ...)``"""
+        """``Concurrent[a, b, ...]`` matches any ``Concurrent(a(), b(), ...)``"""
         with pytest.raises(Concurrent[IndexError, KeyError, ...]):
             raise Concurrent(IndexError(), KeyError())
         with pytest.raises(Concurrent[IndexError, KeyError, ...]):
@@ -82,7 +83,7 @@ class TestConcurrent:
                 raise Concurrent(IndexError(), ValueError())
 
     def test_specialised_base(self):
-        """Specialised ``Concurrent[a]`` catches also ``Concurrent(b(): a)``"""
+        """``Concurrent[a]`` matches also ``Concurrent(b(): a)``"""
         with pytest.raises(Concurrent[LookupError]):
             raise Concurrent(IndexError())
         with pytest.raises(Concurrent[LookupError]):
@@ -97,6 +98,7 @@ class TestConcurrent:
                 raise Concurrent(KeyError(), IndexError())
 
     def test_specialised_identity(self):
+        """Various ``Concurrent`` forms are identical, not just equal"""
         assert type(Concurrent()) is Concurrent
         assert Concurrent[...] is Concurrent
         assert type(Concurrent(KeyError())) is Concurrent[KeyError]
@@ -106,6 +108,7 @@ class TestConcurrent:
             is Concurrent[KeyError, IndexError]
 
     def test_specialised_subclass(self):
+        """``Concurrent[T] :> Concurrent[U]`` if ``T :> U``"""
         assert issubclass(Concurrent[KeyError], Concurrent)
         assert issubclass(Concurrent[IndexError], Concurrent)
         assert issubclass(Concurrent[IndexError, KeyError], Concurrent)

--- a/usim_pytest/test_types/test_concurrent_exception.py
+++ b/usim_pytest/test_types/test_concurrent_exception.py
@@ -122,3 +122,7 @@ class TestConcurrent:
         assert not issubclass(KeyError, Concurrent[KeyError])
         assert not issubclass(KeyError, Concurrent[...])
         assert not issubclass(KeyError, Concurrent[KeyError, ...])
+        # duplicate match does not include unmatched case
+        assert not issubclass(
+            Concurrent[KeyError, LookupError], Concurrent[KeyError, RuntimeError]
+        )

--- a/usim_pytest/test_types/test_concurrent_exception.py
+++ b/usim_pytest/test_types/test_concurrent_exception.py
@@ -3,6 +3,10 @@ import pytest
 from usim import Concurrent
 
 
+class FakeConcurrent:
+    template = BaseException
+
+
 class TestConcurrent:
     """Test the semantics of ``usim.Concurrent``"""
     def test_generic(self):
@@ -94,8 +98,21 @@ class TestConcurrent:
 
     def test_specialised_identity(self):
         assert type(Concurrent()) is Concurrent
+        assert Concurrent[...] is Concurrent
         assert type(Concurrent(KeyError())) is Concurrent[KeyError]
         assert type(Concurrent(KeyError(), IndexError()))\
             is Concurrent[KeyError, IndexError]
         assert type(Concurrent(IndexError(), KeyError()))\
             is Concurrent[KeyError, IndexError]
+
+    def test_specialised_subclass(self):
+        assert issubclass(Concurrent[KeyError], Concurrent)
+        assert issubclass(Concurrent[IndexError], Concurrent)
+        assert issubclass(Concurrent[IndexError, KeyError], Concurrent)
+        assert issubclass(Concurrent[KeyError], Concurrent[KeyError])
+        assert issubclass(Concurrent[IndexError], Concurrent[LookupError])
+        assert issubclass(Concurrent[IndexError, KeyError], Concurrent[KeyError, ...])
+        assert not issubclass(
+            Concurrent[KeyError, ...], Concurrent[IndexError, KeyError]
+        )
+        assert not issubclass(FakeConcurrent, Concurrent)

--- a/usim_pytest/test_types/test_concurrent_exception.py
+++ b/usim_pytest/test_types/test_concurrent_exception.py
@@ -76,3 +76,11 @@ class TestConcurrent:
         with pytest.raises(Concurrent[IndexError, ValueError, ...]):
             with pytest.raises(Concurrent[KeyError, ValueError, ...]):
                 raise Concurrent(IndexError(), ValueError())
+
+    def test_specialised_identity(self):
+        assert type(Concurrent()) is Concurrent
+        assert type(Concurrent(KeyError())) is Concurrent[KeyError]
+        assert type(Concurrent(KeyError(), IndexError()))\
+            is Concurrent[KeyError, IndexError]
+        assert type(Concurrent(IndexError(), KeyError()))\
+            is Concurrent[KeyError, IndexError]

--- a/usim_pytest/test_types/test_concurrent_exception.py
+++ b/usim_pytest/test_types/test_concurrent_exception.py
@@ -1,0 +1,78 @@
+import pytest
+
+from usim import Concurrent
+
+
+class TestConcurrent:
+    """Test the semantics of ``usim.Concurrent``"""
+    def test_generic(self):
+        """Generic ``Concurrent`` is a catch-all"""
+        with pytest.raises(Concurrent):
+            raise Concurrent()
+        with pytest.raises(Concurrent):
+            raise Concurrent(KeyError())
+        with pytest.raises(Concurrent):
+            raise Concurrent(IndexError())
+        with pytest.raises(Concurrent):
+            raise Concurrent(KeyError(), IndexError())
+
+    def test_specialised_single(self):
+        """Specialised ``Concurrent[a]`` catches only ``Concurrent(a())``"""
+        with pytest.raises(Concurrent[IndexError]):
+            raise Concurrent(IndexError())
+        with pytest.raises(Concurrent[KeyError]):
+            raise Concurrent(KeyError())
+        # check that inner test does not catch
+        with pytest.raises(Concurrent[KeyError]):
+            with pytest.raises(Concurrent[IndexError]):
+                raise Concurrent(KeyError())
+        with pytest.raises(Concurrent[IndexError]):
+            with pytest.raises(Concurrent[KeyError]):
+                raise Concurrent(IndexError())
+
+    def test_specialised_multi(self):
+        """Specialised ``Concurrent[a, b]`` catches only ``Concurrent(a(), b())``"""
+        with pytest.raises(Concurrent[IndexError, KeyError]):
+            raise Concurrent(IndexError(), KeyError())
+        with pytest.raises(Concurrent[TypeError, ValueError]):
+            raise Concurrent(TypeError(), ValueError())
+        # reverse order
+        with pytest.raises(Concurrent[IndexError, KeyError]):
+            raise Concurrent(KeyError(), IndexError())
+        with pytest.raises(Concurrent[TypeError, ValueError]):
+            raise Concurrent(ValueError(), TypeError())
+        # check that inner test does not catch
+        with pytest.raises(Concurrent[IndexError, KeyError, ValueError]):
+            with pytest.raises(Concurrent[IndexError, KeyError]):
+                with pytest.raises(Concurrent[KeyError, ValueError]):
+                    raise Concurrent(IndexError(), KeyError(), ValueError())
+
+    def test_specialised_single_open(self):
+        """Specialised ``Concurrent[a, ...]`` catches any ``Concurrent(a(), ...)``"""
+        with pytest.raises(Concurrent[IndexError, ...]):
+            raise Concurrent(IndexError())
+        with pytest.raises(Concurrent[IndexError, ...]):
+            raise Concurrent(IndexError(), KeyError())
+        with pytest.raises(Concurrent[IndexError, ...]):
+            raise Concurrent(IndexError(), TypeError(), KeyError())
+        # check that inner test does not catch
+        with pytest.raises(Concurrent[KeyError, ...]):
+            with pytest.raises(Concurrent[IndexError, ...]):
+                raise Concurrent(KeyError(), ValueError())
+        with pytest.raises(Concurrent[IndexError, ...]):
+            with pytest.raises(Concurrent[KeyError, ...]):
+                raise Concurrent(IndexError(), ValueError())
+
+    def test_specialised_multi_open(self):
+        """Specialised ``Concurrent[a, ...]`` catches any ``Concurrent(a(), ...)``"""
+        with pytest.raises(Concurrent[IndexError, KeyError, ...]):
+            raise Concurrent(IndexError(), KeyError())
+        with pytest.raises(Concurrent[IndexError, KeyError, ...]):
+            raise Concurrent(IndexError(), KeyError(), ValueError())
+        # check that inner test does not catch
+        with pytest.raises(Concurrent[KeyError, ValueError, ...]):
+            with pytest.raises(Concurrent[IndexError, ValueError, ...]):
+                raise Concurrent(KeyError(), ValueError())
+        with pytest.raises(Concurrent[IndexError, ValueError, ...]):
+            with pytest.raises(Concurrent[KeyError, ValueError, ...]):
+                raise Concurrent(IndexError(), ValueError())

--- a/usim_pytest/test_types/test_concurrent_exception.py
+++ b/usim_pytest/test_types/test_concurrent_exception.py
@@ -77,6 +77,21 @@ class TestConcurrent:
             with pytest.raises(Concurrent[KeyError, ValueError, ...]):
                 raise Concurrent(IndexError(), ValueError())
 
+    def test_specialised_base(self):
+        """Specialised ``Concurrent[a]`` catches also ``Concurrent(b(): a)``"""
+        with pytest.raises(Concurrent[LookupError]):
+            raise Concurrent(IndexError())
+        with pytest.raises(Concurrent[LookupError]):
+            raise Concurrent(KeyError())
+        # basetype may catch multiple subtypes
+        with pytest.raises(Concurrent[LookupError]):
+            raise Concurrent(KeyError(), IndexError())
+        # basetype matches do not satisfy missing matchs
+        # check that inner test does not catch
+        with pytest.raises(Concurrent[LookupError]):
+            with pytest.raises(Concurrent[LookupError, TypeError]):
+                raise Concurrent(KeyError(), IndexError())
+
     def test_specialised_identity(self):
         assert type(Concurrent()) is Concurrent
         assert type(Concurrent(KeyError())) is Concurrent[KeyError]

--- a/usim_pytest/test_types/test_concurrent_exception.py
+++ b/usim_pytest/test_types/test_concurrent_exception.py
@@ -116,3 +116,6 @@ class TestConcurrent:
             Concurrent[KeyError, ...], Concurrent[IndexError, KeyError]
         )
         assert not issubclass(FakeConcurrent, Concurrent)
+        assert not issubclass(KeyError, Concurrent[KeyError])
+        assert not issubclass(KeyError, Concurrent[...])
+        assert not issubclass(KeyError, Concurrent[KeyError, ...])

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -1,7 +1,6 @@
 import pytest
 
-from usim import Scope, time, instant
-from usim._primitives.concurrent_exception import Concurrent
+from usim import Scope, time, instant, Concurrent
 
 from ..utility import via_usim
 
@@ -43,7 +42,7 @@ class TestExceptions:
             await (time + after)
             observations += 1
 
-        with pytest.raises(KeyError):
+        with pytest.raises(Concurrent):
             async with Scope() as scope:
                 scope.do(observe(5))
                 await instant
@@ -64,7 +63,7 @@ class TestExceptions:
             await (time + after)
             observations += 1
 
-        with pytest.raises(Concurrent[KeyError, IndexError]):
+        with pytest.raises(Concurrent):
             async with Scope() as scope:
                 scope.do(observe(5))
                 await instant

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -110,3 +110,20 @@ class TestExceptions:
                 scope.do(async_raise(ValueError(), 2))
                 await (time + 2)
                 raise KeyError
+
+    @via_usim
+    async def test_fail_privileged(self):
+        """Failure inside children with privilege is not suppressed"""
+        for exc_type in (AssertionError, KeyboardInterrupt, SystemExit):
+            with pytest.raises(exc_type):
+                async with Scope() as scope:
+                    scope.do(async_raise(IndexError(), 0))
+                    scope.do(async_raise(TypeError(), 0))
+                    scope.do(async_raise(KeyError(), 0))
+                    scope.do(async_raise(exc_type(), 0))
+            with pytest.raises(exc_type):
+                async with Scope() as scope:
+                    scope.do(async_raise(IndexError(), 0))
+                    scope.do(async_raise(TypeError(), 0))
+                    scope.do(async_raise(KeyError(), 0))
+                    raise exc_type

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -113,7 +113,7 @@ class TestExceptions:
 
     @via_usim
     async def test_fail_privileged(self):
-        """Failure inside children with privilege is not suppressed"""
+        """Failure inside children with privileged errors is not collapsed"""
         for exc_type in (AssertionError, KeyboardInterrupt, SystemExit):
             with pytest.raises(exc_type):
                 async with Scope() as scope:

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -84,6 +84,7 @@ class TestExceptions:
             async with Scope() as scope:
                 scope.do(async_raise(IndexError(), 1))
                 raise KeyError
+        assert time.now == 0
 
         with pytest.raises(Concurrent[IndexError]):
             async with Scope() as scope:
@@ -92,6 +93,7 @@ class TestExceptions:
                 scope.do(async_raise(ValueError(), 2))
                 await (time + 2)
                 raise KeyError
+        assert time.now == 1
 
         with pytest.raises(Concurrent[IndexError, TypeError]):
             async with Scope() as scope:
@@ -101,6 +103,7 @@ class TestExceptions:
                 scope.do(async_raise(ValueError(), 2))
                 await (time + 2)
                 raise KeyError
+        assert time.now == 2
 
         with pytest.raises(Concurrent[IndexError, TypeError, ...]):
             async with Scope() as scope:
@@ -110,6 +113,7 @@ class TestExceptions:
                 scope.do(async_raise(ValueError(), 2))
                 await (time + 2)
                 raise KeyError
+        assert time.now == 3
 
     @via_usim
     async def test_fail_privileged(self):

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -1,6 +1,7 @@
 import pytest
 
 from usim import Scope, time, instant
+from usim._primitives.concurrent_exception import Concurrent
 
 from ..utility import via_usim
 
@@ -8,11 +9,6 @@ from ..utility import via_usim
 async def async_raise(exc: BaseException):
     """Raise an exception in an ``await`` or ``scope.do`` context"""
     raise exc
-
-
-class MultiError(Exception):
-    # FAKE until this actually exists
-    ...
 
 
 class TestExceptions:
@@ -68,7 +64,7 @@ class TestExceptions:
             await (time + after)
             observations += 1
 
-        with pytest.raises(MultiError[KeyError, IndexError]):
+        with pytest.raises(Concurrent[KeyError, IndexError]):
             async with Scope() as scope:
                 scope.do(observe(5))
                 await instant


### PR DESCRIPTION
This pull request addresses the exception handling of issue #26. This pull request includes:

* [x] unit tests to replicate the issue,
* [x] automatic cancellation of a scope if any children fail,
* [x] propagation of errors from children through the scope,
* [x] a new exception ``Concurrent`` for multiple concurrent errors,
* [x] cleanup of finished children.

This pull request also changes some semantics of ``Task``s and ``Scope``s that were/are not publicly defined. Tasks are considered "Running" in the same time step of creation, and a Scope will  forcefully cancel child Tasks during shutdown.