### PR TITLE
Readable Exceptions

### DIFF
--- a/usim/_core/loop.py
+++ b/usim/_core/loop.py
@@ -15,18 +15,6 @@ from .waitq import WaitQueue
 
 
 # Errors
-class ActivityError(RuntimeError):
-    r"""An activity failed to handle an exception"""
-    def __init__(self, activity: Coroutine, signal: Optional[BaseException]):
-        self.activity = activity
-        self.signal = signal
-        super().__init__(
-            'Activity %r raised an exception in response to %s' % (
-                activity, signal
-            )
-        )
-
-
 class ActivityLeak(RuntimeError):
     r"""An activity failed to contain output"""
     def __init__(self, activity: Coroutine, signal: Optional[BaseException], result):
@@ -232,8 +220,6 @@ class Loop:
             if err.args:
                 # async def ... return foo -> StopIteration.args == (foo,)
                 raise ActivityLeak(target, signal, err.args[0]) from err
-        except BaseException as err:
-            raise ActivityError(target, signal=signal) from err
 
     def schedule(
             self,

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -271,8 +271,8 @@ class Scope:
             exc = Concurrent(*concurrent)
             # exc.__cause__ shows up in the stacktrace before exc
             #
-            # Since everything leading up to here is not relevant,
-            # for users there is no harm replacing it. Python only
+            # Since everything leading up to here is not relevant
+            # for users, there is no harm replacing it. Python only
             # allows one cause, so we have to choose one arbitrarily
             # - the first *might* be the start of a cascade at least.
             exc.__cause__ = concurrent[0]

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -268,7 +268,15 @@ class Scope:
                 if not isinstance(exc, suppress):
                     concurrent.append(exc)
         if concurrent:
-            return None, Concurrent(*concurrent)
+            exc = Concurrent(*concurrent)
+            # exc.__cause__ shows up in the stacktrace before exc
+            #
+            # Since everything leading up to here is not relevant,
+            # for users there is no harm replacing it. Python only
+            # allows one cause, so we have to choose one arbitrarily
+            # - the first *might* be the start of a cascade at least.
+            exc.__cause__ = concurrent[0]
+            return None, exc
         return None, None
 
     def _propagate_exceptions(self, exc_type, exc_val):

--- a/usim_pytest/utility.py
+++ b/usim_pytest/utility.py
@@ -3,7 +3,7 @@ from functools import wraps
 from collections import namedtuple
 
 from usim import run
-from usim._core.loop import ActivityError, __LOOP_STATE__
+from usim._core.loop import __LOOP_STATE__
 
 
 RT = TypeVar('RT')
@@ -74,17 +74,8 @@ def via_usim(test_case: Callable[..., Coroutine]):
             nonlocal test_completed
             await test_case(*args, **kwargs)
             test_completed = True
-        # pytest currently ignores __tracebackhide__ if we re-raise
-        # https://github.com/pytest-dev/pytest/issues/1904
-        __tracebackhide__ = True
-        # >>> This is not the frame you are looking for. Do read on. <<<
-        try:
-            result = run(complete_test_case())
-        except ActivityError as err:
-            # unwrap any exceptions
-            raise err.__cause__
-        else:
-            if not test_completed:
-                raise UnfinishedTest(test_case)
-            return result
+        result = run(complete_test_case())
+        if not test_completed:
+            raise UnfinishedTest(test_case)
+        return result
     return run_test


### PR DESCRIPTION
This pull request improves the readability of exceptions. This pull request includes:

* [x] unhandled exceptions are not wrapped by ``ActivityError``,
* [x] ``Concurrent`` errors include the traceback of the first child.

See also issue #38.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mainekuehn/usim/39)
<!-- Reviewable:end -->
