### PR TITLE
Allow zero delay

### DIFF
--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -148,11 +148,16 @@ class Scope:
         which must exit without ``await``\ ing or ``yield``\ ing anything.
         """
         assert after is None or at is None,\
-            "schedule date must be either absolute or relative"
+            "start date must be either absolute or relative"
+        # resolve "now" to what the event loop expects
+        if after == 0:
+            after = None
+        elif at == __LOOP_STATE__.LOOP.time:
+            at = None
         assert after is None or after > 0,\
-            "schedule date must not be in the past"
+            "start date must not be in the past"
         assert at is None or at > __LOOP_STATE__.LOOP.time,\
-            "schedule date must not be in the past"
+            "start date must not be in the past"
         child_task = Task(payload, self, delay=after, at=at)
         __LOOP_STATE__.LOOP.schedule(
             child_task.__runner__,

--- a/usim/_primitives/timing.py
+++ b/usim/_primitives/timing.py
@@ -258,9 +258,15 @@ class Delay(Notification):
         delay = time + 20
         await delay      # delay for 20
         await delay      # delay for 20 again
-        print(time.now)  # gives 40
+        print(time.now)  # prints 40
 
-    The expression ``time + duration`` is equivalent to ``Delay(duration)``.
+    Because :py:class:`~.Delay` represents a time duration it is not a
+    :py:class:`~.Condition` that becomes true at some point in time.
+    If a Condition is required, use ``time == time.now + duration`` instead.
+
+    The expression ``time + duration`` is equivalent to ``Delay(duration)``
+    if ``duration`` is positive. If ``duration`` is ``0``, ``time + duration``
+    is equivalent to an :py:class:`~.Instant`.
     """
     __slots__ = ('duration',)
 

--- a/usim/_primitives/timing.py
+++ b/usim/_primitives/timing.py
@@ -279,6 +279,42 @@ class Delay(Notification):
     def __str__(self):
         return 'usim.time + {}'.format(self.duration)
 
+    # NOTE: Python objects *always* have __bool__, which defaults
+    # to True. We could debug-protect against misuse of bool(time + 3)
+    # but that would lead to observably different behaviour.
+    # If we always raise an error, that is inconsistent with other objects.
+
+    if __debug__:
+        def __and__(self, other):
+            raise TypeError((
+                "Operator & not supported for delays\n\n"
+                "Delays (time + delay) are measured from the ongoing current time,\n"
+                "They do not provide a Condition, but a Notification. Operators of\n"
+                "Condition are not supported.\n"
+                "\n"
+                "If a Condition is required, use 'time == time.now + delay' instead"
+            ))
+
+        def __or__(self, other):
+            raise TypeError((
+                "Operator | not supported for delays\n\n"
+                "Delays (time + delay) are measured from the ongoing current time,\n"
+                "They do not provide a Condition, but a Notification. Operators of\n"
+                "Condition are not supported.\n"
+                "\n"
+                "If a Condition is required, use 'time == time.now + delay' instead"
+            ))
+
+        def __invert__(self):
+            raise TypeError((
+                "Operator ~ not supported for delays\n\n"
+                "Delays (time + delay) are measured from the ongoing current time,\n"
+                "They do not provide a Condition, but a Notification. Operators of\n"
+                "Condition are not supported.\n"
+                "\n"
+                "If a Condition is required, use 'time == time.now + delay' instead"
+            ))
+
 
 class Time:
     r"""

--- a/usim/_primitives/timing.py
+++ b/usim/_primitives/timing.py
@@ -12,7 +12,7 @@ time can represent more than 285 million years of time accurately.
        it is still not possible to reach :py:class:`Eternity`.
        This may change in the future.
 """
-from typing import Coroutine, Generator, Any, AsyncIterable
+from typing import Coroutine, Generator, Any, AsyncIterable, Union
 
 from .._core.loop import __LOOP_STATE__, __HIBERNATE__, Interrupt as CoreInterrupt
 from .notification import postpone, Notification
@@ -265,6 +265,7 @@ class Delay(Notification):
     __slots__ = ('duration',)
 
     def __init__(self, duration: float):
+        assert duration > 0, "delay must point at the future"
         super().__init__()
         self.duration = duration
 
@@ -344,7 +345,10 @@ class Time:
         """The current simulation time"""
         return __LOOP_STATE__.LOOP.time
 
-    def __add__(self, other: float) -> Delay:
+    def __add__(self, other: float) -> Union[Delay, Instant]:
+        assert other >= 0, "delay must point at the future"
+        if other == 0:
+            return Instant()
         return Delay(other)
 
     def __ge__(self, other: float) -> After:

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -167,9 +167,11 @@ class TestScoping:
     @assertion_mode
     @via_usim
     async def test_do_misuse(self):
+        fail_pass = async_pass()
         with pytest.raises(AssertionError):
             async with Scope() as scope:
-                scope.do(async_pass(), at=-1)
+                scope.do(fail_pass, at=-1)
         with pytest.raises(AssertionError):
             async with Scope() as scope:
-                scope.do(async_pass(), after=-1)
+                scope.do(fail_pass, after=-1)
+        fail_pass.close()

--- a/usim_pytest/test_types/test_time.py
+++ b/usim_pytest/test_types/test_time.py
@@ -19,6 +19,12 @@ class TestTime:
             await time
         with pytest.raises(TypeError):
             await (time <= 100)
+        with pytest.raises(TypeError):
+            ~(time + 3)
+        with pytest.raises(TypeError):
+            (time + 3) & (time == 3)
+        with pytest.raises(TypeError):
+            (time + 3) | (time == 3)
 
     @assertion_mode
     @via_usim

--- a/usim_pytest/test_types/test_time.py
+++ b/usim_pytest/test_types/test_time.py
@@ -4,7 +4,7 @@ import pytest
 
 from usim import time, until, eternity, instant, each
 
-from ..utility import via_usim
+from ..utility import via_usim, assertion_mode
 
 
 class TestTime:
@@ -20,12 +20,21 @@ class TestTime:
         with pytest.raises(TypeError):
             await (time <= 100)
 
+    @assertion_mode
+    @via_usim
+    async def test_debug_misuse(self):
+        with pytest.raises(AssertionError):
+            await (time + -1)
+
     @via_usim
     async def test_delay(self):
         start, delay = time.now, 20
         for seq in range(5):
             assert start + (delay * seq) == time.now
             await (time + delay)
+        assert start + (delay * 5) == time.now
+        # allow for 0 delay
+        await (time + 0)
         assert start + (delay * 5) == time.now
 
     @via_usim


### PR DESCRIPTION
This pull request addresses usability of delays. This pull request includes:

* allow zero delays as in `time + 0`,
* provide rich errors messages on misuse of delays as Condition types,
* allow `scope.do(..., at=time.now)` and `scope.do(..., after=0)`,
* provides unittests.

Closes #35 and closes #41.