### PR TITLE
uSim notifications in Simpy

### DIFF
--- a/usim/py/_awaitable.py
+++ b/usim/py/_awaitable.py
@@ -1,0 +1,60 @@
+from typing import Awaitable, TypeVar, Generic
+from .. import Flag, until
+
+
+R = TypeVar('R')
+
+
+class AwaitableEvent(Generic[R]):
+    """
+    Wraps an Awaitable as a SimPy :py:class:`~usim.py.events.Event`
+
+    This type only exists for internal usage to allow a
+    :py:class:`~usim.py.events.Process` to ``yield`` a :py:class:`~.Notification`
+    or :term:`activity`.
+    It is not intended for manual instantiation and does not provide the ``Event``
+    interface beyond what is needed internally.
+
+    If you encounter a :py:class:`~.NotificationEvent` during a simulation,
+    **this is a bug**.
+    """
+    @property
+    def value(self):
+        try:
+            value, exception = self._value
+        except TypeError:
+            raise AttributeError(
+                f"{self.__class__.__name__!r} object has no attribute 'value' set yet"
+            )
+        else:
+            return value if exception is None else exception
+
+    @property
+    def ok(self) -> bool:
+        return self._value is not None and self._value[1] is None
+
+    def __init__(self, awaitable: Awaitable[R]):
+        self._awaitable = awaitable
+        self._value = None
+        self._ok = None
+        self.defused = True
+
+    async def wait_interruptible(self, interrupted: Flag) -> bool:
+        """
+        Wait for the notification to trigger or the process be ``interrupted``
+
+        Returns ``True`` if the notification triggered or
+        ``False`` if an interrupt occured first.
+        """
+        if interrupted:
+            return False
+        async with until(interrupted):
+            try:
+                result = await self._awaitable
+            except Exception as err:
+                self._value = None, err
+                return True
+            else:
+                self._value = result, None
+                return True
+        return False

--- a/usim_pytest/test_usimpy/test_compatibility.py
+++ b/usim_pytest/test_usimpy/test_compatibility.py
@@ -1,0 +1,30 @@
+from usim import Flag
+
+from .utility import via_usimpy
+
+
+class TestUsim2Simpy:
+    @via_usimpy
+    def test_flag(self, env):
+        """Can trigger and set flags"""
+        flag = Flag()
+        assert not flag
+
+        def trigger_flag(after):
+            yield env.timeout(after)
+            yield flag.set()
+        env.process(trigger_flag(5))
+        yield flag
+        assert env.now == 5
+
+    @via_usimpy
+    def test_coroutine(self, env):
+        """Can yield-as-await coroutines"""
+        assert env.now == 0
+
+        async def ping_pong(value):
+            return value
+        result = yield ping_pong(3)
+        assert result == 3
+        assert env.now == 0
+


### PR DESCRIPTION
This pull request addresses interoperability in issue #21. This pull request includes:

* ``usim.py`` processes may ``yield`` a ``usim`` notification to ``await`` it,
* ``usim.py`` processes may ``yield`` a coroutine to ``await`` it,
* documentation has been expanded with cross-compatibility information.

The initial plan was just to support notifications, not coroutines (aka activities). However, ``usim`` often uses native coroutines to avoid wrappers and it would be extra work to *disallow* coroutines.