### PR TITLE
Task lifetime and cleanup

### DIFF
--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -173,6 +173,12 @@ class Scope:
         if self._interruptable:
             __LOOP_STATE__.LOOP.schedule(self._activity, self._cancel_self)
 
+    def __child_finished__(self, task: Task, failed: bool):
+        if failed:
+            self.__cancel__()
+        if task.__volatile__:
+            self._volatile_children.remove(task)
+
     def _disable_interrupts(self):
         self._interruptable = False
         self._cancel_self.revoke()

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -133,6 +133,7 @@ class Scope:
         :param after: delay after which to start the activity
         :param at: point in time at which to start the activity
         :param volatile: whether the activity is aborted at the end of the scope
+        :raises ScopeClosed: if the scope has ended already
         :return: representation of the ongoing activity
 
         All non-``volatile`` activities are ``await``\ ed at the end of the scope.
@@ -159,6 +160,14 @@ class Scope:
         Aborting ``volatile`` activities is not graceful:
         :py:class:`GeneratorExit` is raised in the activity,
         which must exit without ``await``\ ing or ``yield``\ ing anything.
+
+        The scope assumes exclusive ownership of the ``payload``:
+        no activity should modify the ``payload`` directly.
+        The scope takes the responsibility to ``await`` and
+        cleanup the payload as needed.
+
+        It is not possible to :py:meth:`~.do` activities after the scope has ended.
+        A :py:exc:`~.ScopeClosed` exception is raised in this case.
         """
         if not self._interruptable:
             # we have been given the payload with the expectation of managing it

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -158,7 +158,7 @@ class Scope:
             "start date must not be in the past"
         assert at is None or at > __LOOP_STATE__.LOOP.time,\
             "start date must not be in the past"
-        child_task = Task(payload, self, delay=after, at=at)
+        child_task = Task(payload, self, delay=after, at=at, volatile=volatile)
         __LOOP_STATE__.LOOP.schedule(
             child_task.__runner__,
         )

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -3,7 +3,7 @@ from typing import Coroutine, List, TypeVar, Any, Optional, Tuple
 from .._core.loop import __LOOP_STATE__, Interrupt as CoreInterrupt
 from .notification import Notification, postpone
 from .flag import Flag
-from .task import Task, TaskClosed, TaskState, TaskCancelled
+from .task import Task, TaskClosed, TaskCancelled
 from .concurrent_exception import Concurrent
 
 

--- a/usim/_primitives/task.py
+++ b/usim/_primitives/task.py
@@ -104,9 +104,14 @@ class Task(Awaitable[RT]):
     :note: This class should not be instantiated directly.
            Always use a :py:class:`~.Scope` to create it.
     """
-    __slots__ = 'payload', '_result', '__runner__', '_cancellations', '_done', 'parent'
+    __slots__ = 'payload', '_result', '__runner__', '_cancellations', '_done',\
+                '__volatile__', 'parent'
 
-    def __init__(self, payload: Coroutine[Any, Any, RT], parent: 'Scope', delay, at):
+    def __init__(
+            self,
+            payload: Coroutine[Any, Any, RT], parent: 'Scope',
+            delay: Optional[float], at: Optional[float], volatile: bool,
+    ):
         @wraps(payload)
         async def payload_wrapper():
             # check for a pre-run cancellation
@@ -144,6 +149,7 @@ class Task(Awaitable[RT]):
                 cancellation.revoke()
             try_close(self.payload)
             self._done.__set_done__()
+        self.__volatile__ = volatile
         self._cancellations = []  # type: List[CancelTask]
         self._result = None  \
             # type: Optional[Tuple[Optional[RT], Optional[BaseException]]]

--- a/usim/_primitives/task.py
+++ b/usim/_primitives/task.py
@@ -117,6 +117,7 @@ class Task(Awaitable[RT]):
             # check for a pre-run cancellation
             if self._result is not None:
                 try_close(self.payload)
+                self.parent.__child_finished__(self, failed=True)
                 return
             try:
                 # We suspend the Task internally instead of waiting to start

--- a/usim/_primitives/task.py
+++ b/usim/_primitives/task.py
@@ -134,17 +134,19 @@ class Task(Awaitable[RT]):
                     self, err.subject
                 )
                 self._result = None, err.__transcript__
+                self.parent.__child_finished__(self, failed=False)
             except GeneratorExit:
                 # We are NOT allowed to do any async once the generator
                 # exits forcefully.
                 # We should only receive GeneratorExit due to a forceful
                 # termination in self.__close__ or during cleanup.
-                pass
+                self.parent.__child_finished__(self, failed=False)
             except BaseException as err:
                 self._result = None, err
-                self.parent.__cancel__()
+                self.parent.__child_finished__(self, failed=True)
             else:
                 self._result = result, None
+                self.parent.__child_finished__(self, failed=False)
             for cancellation in self._cancellations:
                 cancellation.revoke()
             try_close(self.payload)

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -1,3 +1,5 @@
+import inspect
+
 import pytest
 
 from usim import Scope, time, instant, Concurrent
@@ -197,3 +199,15 @@ class TestScoping:
         async with Scope() as scope:
             scope.do(spawn_late(scope))
         assert time.now == 10
+
+    @via_usim
+    async def test_spawn_after_shutdown(self):
+        async def activity(value):
+            return value
+
+        async with Scope() as scope:
+            pass
+        payload = activity(3)
+        with pytest.raises(RuntimeError):
+            scope.do(payload)
+        assert inspect.getcoroutinestate(payload) == inspect.CORO_CLOSED

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -186,3 +186,14 @@ class TestScoping:
         with pytest.raises(Concurrent[KeyError]):
             async with Scope() as scope:
                 scope.do(fail_late(scope))
+
+    @via_usim
+    async def test_spawn_late(self):
+        """Test spawning during graceful shutdown"""
+        async def spawn_late(scope):
+            await scope
+            scope.do(time + 10)
+
+        async with Scope() as scope:
+            scope.do(spawn_late(scope))
+        assert time.now == 10

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -175,3 +175,14 @@ class TestScoping:
             async with Scope() as scope:
                 scope.do(fail_pass, after=-1)
         fail_pass.close()
+
+    @via_usim
+    async def test_teardown_late(self):
+        """Test that the scope may receive failures during shutdown"""
+        async def fail_late(scope):
+            await scope
+            raise KeyError
+
+        with pytest.raises(Concurrent[KeyError]):
+            async with Scope() as scope:
+                scope.do(fail_late(scope))


### PR DESCRIPTION
This pull request addresses #29. This pull request includes:

* child ``Task``s of a ``Scope`` are not kept alive by the scope after they are finished,
* errors in child tasks are immediately collected by their parent scope,
* it is an error to ``Scope.do`` if the scope has ended already,
* fixed reaction of scope on failure or starting of child tasks while the scope shuts down,
* subclasses of ``Scope`` can override how they react to child errors.

Closes #29.