### PR TITLE
Two column layout for documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.viewcode',
     'sphinxcontrib_trio',
+    'sphinxcontrib.contentui',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/topics/debug.rst
+++ b/docs/source/topics/debug.rst
@@ -47,14 +47,14 @@ Assertions and Debug Extensions
     The error includes some information to tell you what went wrong,
     and attempts to explain how to fix it.
 
-.. content-tabs:: left-col
-
     In addition to validating your simulation,
     assertion mode also provides rich exception messages.
     For example, erroneously using ``await time`` provides
     an Exception with additional help on intended usage.
 
 .. content-tabs:: right-col
+
+    .. rubric:: Rich error messages in assertion mode
 
     .. code:: none
 
@@ -111,6 +111,8 @@ Omitting Assertions
 
 .. content-tabs:: right-col
 
+    .. rubric:: Simulating in optimised mode
+
     .. code:: bash
 
         python3 -O my_simulation.py
@@ -127,6 +129,8 @@ Omitting Assertions
     the regular Python error message.
 
 .. content-tabs:: right-col
+
+    .. rubric:: Regular Python error messages in optimized mode
 
     .. code:: none
 

--- a/docs/source/topics/debug.rst
+++ b/docs/source/topics/debug.rst
@@ -1,105 +1,139 @@
 Usage Assertions and Performance
 ================================
 
-In order to help writing correct simulations,
-μSim uses a wide range of usage assertions.
-These generally verify argument values and types in advance,
-so that you can pinpoint where errors originate.
+.. container:: left-col
 
-At the same time, μSim strives to provide
-best performance for correct simulations.
-Once you have verified your simulation,
-you can omit all consistency assertions with zero cost.
+    In order to help writing correct simulations,
+    μSim uses a wide range of usage assertions.
+    These generally verify argument values and types in advance,
+    so that you can pinpoint where errors originate.
 
-:note: μSim runs in assertion mode by default.
+.. container:: left-col
+
+    At the same time, μSim strives to provide
+    best performance for correct simulations.
+    Once you have verified your simulation,
+    you can omit all consistency assertions with zero cost.
+
+.. container:: content-tabs right-col
+
+    .. note:: μSim runs in assertion mode by default.
 
 Assertions and Debug Extensions
 -------------------------------
 
-μSim uses assertions when checking
-the internal logic of simulations.
-For example, :term:`time` in a simulation must always advance
-into the future -
-assertions protect against creating events in the past:
+.. content-tabs:: left-col
 
-.. code:: python3
+    μSim uses assertions when checking
+    the internal logic of simulations.
+    For example, :term:`time` in a simulation must always advance
+    into the future -
+    assertions protect against creating events in the past.
 
-    >>> from usim import time, run
-    >>>
-    >>> async def wait(delay):
-    ...     await (time + delay)
-    ...
-    >>> run(wait(-20))  # delay until a time that has already passed
+.. content-tabs:: right-col
 
-When run regularly, this will fail with an :py:exc:`AssertionError`.
-The error includes some information to tell you what went wrong,
-and attempts to explain how to fix it.
+    .. code:: python3
 
-In addition to validating your simulation,
-assertion mode also provides rich exception messages.
-For example, erroneously using ``await time`` provides
-an Exception with additional help on intended usage:
+        >>> from usim import time, run
+        >>>
+        >>> async def wait(delay):
+        ...     await (time + delay)
+        ...
+        >>> run(wait(-20))  # delay until a time that has already passed
 
-.. code:: none
+.. content-tabs:: left-col
 
-    TypeError: 'time' cannot be used in 'await' expression
+    When run regularly, this will fail with an :py:exc:`AssertionError`.
+    The error includes some information to tell you what went wrong,
+    and attempts to explain how to fix it.
 
-    Use 'time' to derive operands for specific expressions:
-    * 'await (time + duration)' to delay for a specific duration
-    * 'await (time == date)' to proceed at a specific point in time
-    * 'await (time >= date)' to proceed at or after a point in time
-    * 'await (time < date)' to indefinitely block after a point in time
+.. content-tabs:: left-col
 
-    To get the current time, use 'time.now'
+    In addition to validating your simulation,
+    assertion mode also provides rich exception messages.
+    For example, erroneously using ``await time`` provides
+    an Exception with additional help on intended usage.
+
+.. content-tabs:: right-col
+
+    .. code:: none
+
+        TypeError: 'time' cannot be used in 'await' expression
+
+        Use 'time' to derive operands for specific expressions:
+        * 'await (time + duration)' to delay for a specific duration
+        * 'await (time == date)' to proceed at a specific point in time
+        * 'await (time >= date)' to proceed at or after a point in time
+        * 'await (time < date)' to indefinitely block after a point in time
+
+        To get the current time, use 'time.now'
 
 Reacting to Usage Errors
 ------------------------
 
-The purpose of assertions is to help simulation developers
-detect and remove inconsistencies and logic errors.
-They are not meant for the simulation itself to
-react to or even attempt recovery.
+.. content-tabs:: left-col
 
-.. code:: python3
+    The purpose of assertions is to help simulation developers
+    detect and remove inconsistencies and logic errors.
+    They are not meant for the simulation itself to
+    react to or even attempt recovery.
 
-    >>> try:
-    ...     risk.take_chance()
-    ... except KeyError:  # correct - recover from exception state
-    ...     risk.recover()
-    ... except AssertionError:  # incorrect - recover from corruption
-    ...     risk.recover()
+    When an assertion of μSim fails, this means your simulation
+    is in an undefined state.
+    Instead of trying to recover, you should fix the root cause
+    of the erroneous condition.
 
-When an assertion of μSim fails, this means your simulation
-is in an undefined state.
-Instead of trying to recover, you should fix the root cause
-of the erroneous condition.
+.. content-tabs:: right-col
+
+    .. code:: python3
+
+        >>> try:
+        ...     risk.take_chance()
+        ... except KeyError:  # correct - recover from exception state
+        ...     risk.recover()
+        ... except AssertionError:  # incorrect - recover from corruption
+        ...     risk.recover()
 
 Omitting Assertions
 -------------------
 
-While assertions are important for verification,
-they incur a runtime performance overhead.
-If you trust your simulation to not need assertions,
-you can switch off all assertions to gain performance.
+.. content-tabs:: left-col
 
-Starting Python with the :option:`-O` flag disables
-μSim's assertion mode:
+    While assertions are important for verification,
+    they incur a runtime performance overhead.
+    If you trust your simulation to not need assertions,
+    you can switch off all assertions to gain performance.
 
-.. code:: bash
+.. content-tabs:: left-col
 
-    python3 -O my_simulation.py
+    Starting Python with the :option:`-O` flag disables
+    μSim's assertion mode.
 
-In optimised mode, assertions are completely removed from μSim.
-There is no runtime overhead from checking debug mode versus optimised mode.
+.. content-tabs:: right-col
 
-In addition to disabling assertions, rich exception messages are removed as well.
-For example, erroneously using ``await time`` provides
-the regular Python error message.
+    .. code:: bash
 
-.. code:: none
+        python3 -O my_simulation.py
 
-    TypeError: object Time can't be used in 'await' expression
+.. content-tabs:: left-col
 
-Notably, optimised mode throws the same exceptions as assertion mode
-(except for :py:exc:`AssertionError`).
-Only the error message differs.
+    In optimised mode, assertions are completely removed from μSim.
+    There is no runtime overhead from checking debug mode versus optimised mode.
+
+.. content-tabs:: left-col
+
+    In addition to disabling assertions, rich exception messages are removed as well.
+    For example, erroneously using ``await time`` provides
+    the regular Python error message.
+
+.. content-tabs:: right-col
+
+    .. code:: none
+
+        TypeError: object Time can't be used in 'await' expression
+
+.. content-tabs:: left-col
+
+    Notably, optimised mode throws the same exceptions as assertion mode
+    (except for :py:exc:`AssertionError`).
+    Only the error message differs.

--- a/docs/source/topics/exceptions.rst
+++ b/docs/source/topics/exceptions.rst
@@ -1,173 +1,204 @@
 Concurrent Activities and Exceptions
 ====================================
 
-In complex simulations, it is inevitable that things go wrong sometimes
-- in some cases, failure is even an expected part of the simulation itself.
-This makes it important to make failures explicit,
-but also to have tools to handle them.
+.. container:: left-col
 
-μSim extends the normal Python Exception model with two additions:
-A :py:class:`~usim.Scope` can perform multiple actions at once,
-and thus may encounter several failures at once.
-Similarly, several :py:exc:`~usim.Concurrent` exceptions may need to
-be handled individually or all at once.
+    In complex simulations, it is inevitable that things go wrong sometimes
+    - in some cases, failure is even an expected part of the simulation itself.
+    This makes it important to make failures explicit,
+    but also to have tools to handle them.
+
+    μSim extends the normal Python Exception model with two additions:
+    A :py:class:`~usim.Scope` can perform multiple actions at once,
+    and thus may encounter several failures at once.
+    Similarly, several :py:exc:`~usim.Concurrent` exceptions may need to
+    be handled individually or all at once.
 
 Concurrency and Exceptions
 --------------------------
 
-The purpose of a :py:class:`~usim.Scope` is to :py:meth:`~usim.Scope.do`
-activities concurrently, alongside a main activity represented
-by the Scope body itself.
-Consequently, we can separate exceptions into synchronous exceptions in the body,
-or :py:exc:`~usim.Concurrent` exceptions in a child activity.
+.. content-tabs:: left-col
 
-.. code:: python3
+    The purpose of a :py:class:`~usim.Scope` is to :py:meth:`~usim.Scope.do`
+    activities concurrently, alongside a main activity represented
+    by the Scope body itself.
+    Consequently, we can separate exceptions into synchronous exceptions in the body,
+    or :py:exc:`~usim.Concurrent` exceptions in a child activity.
 
-    async def araise(what: BaseException):
-        raise what
+.. container:: content-tabs right-col
 
-    async def scope_exception_demo():
-        """Demo that randomly fails in the body or child of a Scope"""
-        async with Scope() as scope:
-            delay = random.random()
-            scope.do(
-                araise(RuntimeError('child')),  # A: concurrent exception
-                after=delay
-            )
-            await (time + 1 - delay)
-            raise RuntimeError('body')          # B: synchronous exception
+    .. rubric:: Demo that randomly fails in the body or child of a Scope
 
-Any exception that happens synchronously in the body is a failure of the
-:py:class:`~usim.Scope` itself.
-In the example, the ``RuntimeError('body')`` will teardown the scope and
-then propagate onwards.
+    .. code:: python3
 
-Any exception that happens concurrently in a child is a failure of the
-payloads, not the :py:class:`~usim.Scope`.
-In the example, the ``RuntimeError('child')`` will cause the
-:py:class:`~usim.Scope` to shut down and re-raise the exception as a
-``Concurrent(RuntimeError('child'))``.
+        async def araise(what: BaseException):
+            raise what
+
+        async def scope_exception_demo():
+            async with Scope() as scope:
+                delay = random.random()
+                scope.do(
+                    araise(RuntimeError('child')),  # A: concurrent exception
+                    after=delay
+                )
+                await (time + 1 - delay)
+                raise RuntimeError('body')          # B: synchronous exception
+
+.. content-tabs:: left-col
+
+    Any exception that happens synchronously in the body is a failure of the
+    :py:class:`~usim.Scope` itself.
+    In the example, the ``RuntimeError('body')`` will teardown the scope and
+    then propagate onwards.
+
+    Any exception that happens concurrently in a child is a failure of the
+    payloads, not the :py:class:`~usim.Scope`.
+    In the example, the ``RuntimeError('child')`` will cause the
+    :py:class:`~usim.Scope` to shut down and re-raise the exception as a
+    ``Concurrent(RuntimeError('child'))``.
 
 Handling Concurrent Exceptions
 ------------------------------
 
-The :py:exc:`~usim.Concurrent` exception model is made to integrate with
-Python's regular ``try``/``except`` exception handling machinery.
-Synchronous exceptions do not need any extra effort to handle.
-The :py:exc:`~usim.Concurrent` exceptions have the required, additional
-error handling built in.
-To handle a :py:exc:`~usim.Concurrent` exception of a specific type,
-use ``except Concurrent[ExceptionType]`` instead of ``except ExceptionType``:
+.. content-tabs:: left-col
 
-.. code:: python3
+    The :py:exc:`~usim.Concurrent` exception model is made to integrate with
+    Python's regular ``try``/``except`` exception handling machinery.
+    Synchronous exceptions do not need any extra effort to handle.
+    The :py:exc:`~usim.Concurrent` exceptions have the required, additional
+    error handling built in.
+    To handle a :py:exc:`~usim.Concurrent` exception of a specific type,
+    use ``except Concurrent[ExceptionType]`` instead of ``except ExceptionType``.
 
-    async def handle_exception_demo()
-        """Demo for handling concurrent/synchronous exceptions"""
-        try:
-            await scope_exception_demo()
-        except RuntimeError as err:
-            print('Handled synchronous exception:', err)
-        except Concurrent[RuntimeError] as err:
-            print('Handled concurrent exception:', err)
+.. content-tabs:: right-col
 
-μSim guarantees that you never have to handle both a regular and a
-:py:exc:`~usim.Concurrent` exception at the same time - it is an "either or" situation.
-Consequently, you can safely use separate error handlers for either exception flavour.
-:py:exc:`~usim.Concurrent` exceptions follow the regular subclassing relations
-of exceptions -- for example, ``Concurrent[LookupError]`` matches both
-``Concurrent[KeyError]`` and ``Concurrent[IndexError]``.
+    .. rubric:: Demo for handling concurrent/synchronous exceptions
 
-.. note::
+    .. code:: python3
 
-    μSim considers the use of a :py:class:`~usim.Scope` an implementation detail of
-    functions and abstractions that should *not* be visible to users.
-    Consequently, we handle any :py:exc:`~usim.Concurrent` exception internally
-    and only propagate regular exceptions.
-    While this is not enforced for custom functions and abstractions,
-    we strongly recommend to adhere to this convention.
+        async def handle_exception_demo()
+            try:
+                await scope_exception_demo()
+            except RuntimeError as err:
+                print('Handled synchronous exception:', err)
+            except Concurrent[RuntimeError] as err:
+                print('Handled concurrent exception:', err)
+
+.. content-tabs:: left-col
+
+    μSim guarantees that you never have to handle both a regular and a
+    :py:exc:`~usim.Concurrent` exception at the same time - it is an "either or" situation.
+    Consequently, you can safely use separate error handlers for either exception flavour.
+    :py:exc:`~usim.Concurrent` exceptions follow the regular subclassing relations
+    of exceptions -- for example, ``Concurrent[LookupError]`` matches both
+    ``Concurrent[KeyError]`` and ``Concurrent[IndexError]``.
+
+    .. note::
+
+        μSim considers the use of a :py:class:`~usim.Scope` an implementation detail of
+        functions and abstractions that should *not* be visible to users.
+        Consequently, we handle any :py:exc:`~usim.Concurrent` exception internally
+        and only propagate regular exceptions.
+        While this is not enforced for custom functions and abstractions,
+        we strongly recommend to adhere to this convention.
 
 Concurrency Privileges
 ^^^^^^^^^^^^^^^^^^^^^^
 
-μSim itself is a highly concurrent, exception driven library.
-This means that certain exceptions must propagate unobstructed,
-while others are suppressed at well-defined points.
-In order not to require users to manually adhere to such unwritten rules,
-μSim has a concept for exception privileges in concurrent situations.
+.. content-tabs:: left-col
 
-Task local exceptions
-    Python's :py:exc:`GeneratorExit` and μSim's internal ``Interrupt``
-    represent the teardown of a Task or parts of it.
-    In the Task they belong to, these exceptions will replace all
-    other synchronous or concurrent exceptions; otherwise, they are suppressed.
-    As a result, you do not have to worry about re-raising an ``Interrupt`` and
-    you should never encounter a ``Concurrent[GeneratorExit]``, for example.
+    μSim itself is a highly concurrent, exception driven library.
+    This means that certain exceptions must propagate unobstructed,
+    while others are suppressed at well-defined points.
+    In order not to require users to manually adhere to such unwritten rules,
+    μSim has a concept for exception privileges in concurrent situations.
 
-Application global exceptions
-    Python's :py:exc:`SystemExit`, :py:exc:`KeyboardInterrupt`, and
-    :py:exc:`AssertionError` [#debug]_ represent the teardown of the entire simulation.
-    These exceptions supersede any synchronous and concurrent exceptions,
-    and are always propagated as regular, synchronous exceptions.
+    Task local exceptions
+        Python's :py:exc:`GeneratorExit` and μSim's internal ``Interrupt``
+        represent the teardown of a Task or parts of it.
+        In the Task they belong to, these exceptions will replace all
+        other synchronous or concurrent exceptions; otherwise, they are suppressed.
+        As a result, you do not have to worry about re-raising an ``Interrupt`` and
+        you should never encounter a ``Concurrent[GeneratorExit]``, for example.
 
-As a result, μSim will do the correct thing by default.
-You only have to worry about μSim's internal exceptions if you use catch-all
-exception handlers such as ``except BaseException:`` or even ``except:``.
-In case you are unsure, ``raise`` at the end of a handler to let exceptions propagate.
+    Application global exceptions
+        Python's :py:exc:`SystemExit`, :py:exc:`KeyboardInterrupt`, and
+        :py:exc:`AssertionError` [#debug]_ represent the teardown of the entire simulation.
+        These exceptions supersede any synchronous and concurrent exceptions,
+        and are always propagated as regular, synchronous exceptions.
+
+    As a result, μSim will do the correct thing by default.
+    You only have to worry about μSim's internal exceptions if you use catch-all
+    exception handlers such as ``except BaseException:`` or even ``except:``.
+    In case you are unsure, ``raise`` at the end of a handler to let exceptions propagate.
 
 Handling Multiple Exceptions
 ----------------------------
 
-Concurrency means that *several* child tasks may fail at the same :term:`time`.
-As a result, a :py:exc:`~usim.Concurrent` exception may contain several failures
-at once.
+.. content-tabs:: left-col
 
-.. code:: python3
+    Concurrency means that *several* child tasks may fail at the same :term:`time`.
+    As a result, a :py:exc:`~usim.Concurrent` exception may contain several failures
+    at once.
 
-    async def multi_exception_demo():
-        """Demo that fails in multiple children of a Scope"""
-        async with Scope() as scope:
-            scope.do(araise(IndexError('A')))    # A
-            scope.do(araise(KeyError('B')))      # B
-            scope.do(araise(IndexError('C')))    # C
-            await (time + 2)                     # async exceptions arrive here
-            scope.do(araise(KeyError('D')))      # D
+.. content-tabs:: right-col
 
-This example will propagate a single exception :py:exc:`~usim.Concurrent` exception
-containing ``IndexError('A')``, ``KeyError('B')``, and ``IndexError('C')`` --
-the ``KeyError('D')`` is suppressed by the scope stopping itself and its children.
-The *type* of the exception includes all types of its child exceptions,
-namely ``Concurrent[IndexError, KeyError]``.
-Note that neither the *number* nor *order* of exceptions is captured in the type.
+    .. rubric:: Demo that fails in multiple children of a Scope
 
-Use ``[]`` to specialise precisely which concurrent failure you want to handle.
-Multiple subtypes represent an "and" relation -- ``Concurrent[X, Y]`` requires
-both ``X`` and ``Y`` exceptions to be thrown at the same time.
-Including a literal ``...`` means that additional subtypes are allowed --
-``Concurrent[X, Y, ...]`` matches both ``X`` and ``Y`` plus zero or more others.
-Use ``Concurrent[...]`` to handle any concurrent exception.
+    .. code:: python3
 
-.. code:: python3
+        async def multi_exception_demo():
+            async with Scope() as scope:
+                scope.do(araise(IndexError('A')))    # A
+                scope.do(araise(KeyError('B')))      # B
+                scope.do(araise(IndexError('C')))    # C
+                await (time + 2)                     # async exceptions arrive here
+                scope.do(araise(KeyError('D')))      # D
 
-    try:
-        await some_failure()
-    except X:
-        print('Handled a synchronous X exception')
-    except Y, Concurrent[Y]:
-        print('Handled a synchronous or concurrent Y exception')
-    except Concurrent[X, Z]:
-        print('Handled a concurrent X and Z exception')
-    except Concurrent[X], Concurrent[Z]:
-        print('Handled a concurrent X or a concurrent Z exception')
+.. content-tabs:: left-col
 
-As with exception handling in general, avoid too broad exception cases.
-Prefer specific exceptions over general ones,
-e.g. ``Concurrent[KeyError]`` over ``Concurrent[LookupError]``
-or even ``Concurrent[Exception]``.
-If possible, use exact exception subtypes over open ones,
-e.g. ``Concurrent[KeyError, RuntimeError]`` instead of ``Concurrent[KeyError, ...]``.
-Finally, we recommend using ``Concurrent[...]`` only if you want to suppress
-concurrent exceptions unconditionally.
+    This example will propagate a single exception :py:exc:`~usim.Concurrent` exception
+    containing ``IndexError('A')``, ``KeyError('B')``, and ``IndexError('C')`` --
+    the ``KeyError('D')`` is suppressed by the scope stopping itself and its children.
+    The *type* of the exception includes all types of its child exceptions,
+    namely ``Concurrent[IndexError, KeyError]``.
+    Note that neither the *number* nor *order* of exceptions is captured in the type.
+
+    Use ``[]`` to specialise precisely which concurrent failure you want to handle.
+    Multiple subtypes represent an "and" relation -- ``Concurrent[X, Y]`` requires
+    both ``X`` and ``Y`` exceptions to be thrown at the same time.
+    Including a literal ``...`` means that additional subtypes are allowed --
+    ``Concurrent[X, Y, ...]`` matches both ``X`` and ``Y`` plus zero or more others.
+    Use ``Concurrent[...]`` to handle any concurrent exception.
+
+.. content-tabs:: right-col
+
+    .. rubric:: Specializing concurrent exceptions
+
+    .. code:: python3
+
+        try:
+            await some_failure()
+        except X:
+            print('Handled a synchronous X exception')
+        except Y, Concurrent[Y]:
+            print('Handled a synchronous or concurrent Y exception')
+        except Concurrent[X, Z]:
+            print('Handled a concurrent X and Z exception')
+        except Concurrent[X], Concurrent[Z]:
+            print('Handled a concurrent X or a concurrent Z exception')
+
+.. content-tabs:: left-col
+
+    As with exception handling in general, avoid too broad exception cases.
+    Prefer specific exceptions over general ones,
+    e.g. ``Concurrent[KeyError]`` over ``Concurrent[LookupError]``
+    or even ``Concurrent[Exception]``.
+    If possible, use exact exception subtypes over open ones,
+    e.g. ``Concurrent[KeyError, RuntimeError]`` instead of ``Concurrent[KeyError, ...]``.
+    Finally, we recommend using ``Concurrent[...]`` only if you want to suppress
+    concurrent exceptions unconditionally.
 
 
-.. [#debug] For the use of :py:exc:`AssertionError` by μSim,
-            see also :doc:`./debug`.
+    .. [#debug] For the use of :py:exc:`AssertionError` by μSim,
+                see also :doc:`./debug`.

--- a/docs/source/topics/exceptions.rst
+++ b/docs/source/topics/exceptions.rst
@@ -93,6 +93,8 @@ Handling Concurrent Exceptions
     of exceptions -- for example, ``Concurrent[LookupError]`` matches both
     ``Concurrent[KeyError]`` and ``Concurrent[IndexError]``.
 
+.. content-tabs:: right-col
+
     .. note::
 
         μSim considers the use of a :py:class:`~usim.Scope` an implementation detail of

--- a/docs/source/topics/simpy.rst
+++ b/docs/source/topics/simpy.rst
@@ -121,6 +121,8 @@ Using μSim in a SimPy Simulation
     μSim simulations. This allows combining simulations from μSim and SimPy, and
     to gradually convert simulations.
 
+.. content-tabs:: right-col
+
     .. hint::
 
         The :py:mod:`usim.py` documentation also describes how compatibility objects

--- a/docs/source/topics/simpy.rst
+++ b/docs/source/topics/simpy.rst
@@ -41,34 +41,76 @@ Changing imports is all that is required to switch from SimPy to the μSim
 compatibility layer. The core of the `first SimPy example`_ is exactly the
 same for the μSim compatibility layer:
 
-.. code:: python3
+.. content-tabs::
 
-    >>> def car(env):
-    ...     while True:
-    ...         print('Start parking at %d' % env.now)
-    ...         parking_duration = 5
-    ...         yield env.timeout(parking_duration)
-    ...
-    ...         print('Start driving at %d' % env.now)
-    ...         trip_duration = 2
-    ...         yield env.timeout(trip_duration)
-    ...
+    .. tab-container:: usim
+        :title: μSim
+
+        .. code:: python3
+
+        >>> def car(env):
+        ...     while True:
+        ...         print('Start parking at %d' % env.now)
+        ...         parking_duration = 5
+        ...         yield env.timeout(parking_duration)
+        ...
+        ...         print('Start driving at %d' % env.now)
+        ...         trip_duration = 2
+        ...         yield env.timeout(trip_duration)
+        ...
+
+    .. tab-container:: simpy
+        :title: SimPy
+
+        .. code:: python3
+
+        >>> def car(env):
+        ...     while True:
+        ...         print('Start parking at %d' % env.now)
+        ...         parking_duration = 5
+        ...         yield env.timeout(parking_duration)
+        ...
+        ...         print('Start driving at %d' % env.now)
+        ...         trip_duration = 2
+        ...         yield env.timeout(trip_duration)
+        ...
 
 Running this example is *almost* the same as for SimPy:
 only the single line previously used to ``import simpy`` needs changing.
 
-.. code:: python3
+.. content-tabs::
 
-    >>> import usim.py as simpy  # import usim.py instead of simpy
-    >>> env = simpy.Environment()
-    >>> env.process(car(env))
-    <Process(car) object at 0x...>
-    >>> env.run(until=15)
-    Start parking at 0
-    Start driving at 5
-    Start parking at 7
-    Start driving at 12
-    Start parking at 14
+    .. tab-container:: usim
+        :title: μSim
+
+        .. code:: python3
+
+            >>> import usim.py as simpy  # import usim.py instead of simpy
+            >>> env = simpy.Environment()
+            >>> env.process(car(env))
+            <Process<car> object at 0x...>
+            >>> env.run(until=15)
+            Start parking at 0
+            Start driving at 5
+            Start parking at 7
+            Start driving at 12
+            Start parking at 14
+
+    .. tab-container:: simpy
+        :title: SimPy
+
+        .. code:: python3
+
+            >>> import simpy
+            >>> env = simpy.Environment()
+            >>> env.process(car(env))
+            <Process<car> object at 0x...>
+            >>> env.run(until=15)
+            Start parking at 0
+            Start driving at 5
+            Start parking at 7
+            Start driving at 12
+            Start parking at 14
 
 The ``usim.py`` layer not only provides the SimPy API, it can even interoperate with native
 μSim simulations. This allows combining simulations from μSim and SimPy, and

--- a/docs/source/topics/simpy.rst
+++ b/docs/source/topics/simpy.rst
@@ -35,7 +35,7 @@ Using μSim in a SimPy Simulation
 
         .. rubric:: Compatibility Imports
 
-        .. code-block::
+        .. code:: python
 
             # alias to expected name
             import usim.py as simpy
@@ -47,7 +47,7 @@ Using μSim in a SimPy Simulation
 
         .. rubric:: Native Imports
 
-        .. code-block::
+        .. code:: python
 
             # module import
             import simpy
@@ -63,7 +63,7 @@ Using μSim in a SimPy Simulation
 
 .. content-tabs:: right-col
 
-    .. code-block:: python3
+    .. code:: python3
 
         >>> def car(env):
         ...     while True:
@@ -86,7 +86,7 @@ Using μSim in a SimPy Simulation
     .. tab-container:: usim
         :title: μSim
 
-        .. code-block:: python3
+        .. code:: python3
 
             >>> import usim.py as simpy  # import usim.py instead of simpy
             >>> env = simpy.Environment()
@@ -102,7 +102,7 @@ Using μSim in a SimPy Simulation
     .. tab-container:: simpy
         :title: SimPy
 
-        .. code-block:: python3
+        .. code:: python3
 
             >>> import simpy
             >>> env = simpy.Environment()
@@ -143,11 +143,12 @@ Interactions between μSim and SimPy
 
 .. content-tabs:: right-col
 
-    .. code-block:: python3
+    .. rubric:: Partially migrated SimPy process
+
+    .. code:: python3
 
         >>> from usim import time
         >>> def car(env):
-        ...     """Partially migrated SimPy process"""
         ...     trip_duration = 2
         ...     parking_duration = 5
         ...     while True:
@@ -188,11 +189,12 @@ Migrating from SimPy to μSim
 
 .. content-tabs:: right-col
 
-    .. code-block:: python3
+    .. rubric:: Fully migrated SimPy process
+
+    .. code:: python3
 
         >>> from usim import run, time
         >>> async def car():
-        ...     """Fully migrated SimPy process"""
         ...     while True:
         ...         print(f'Start parking at {time.now}')
         ...         await (time + 5)
@@ -214,7 +216,9 @@ Migrating from SimPy to μSim
 
 .. content-tabs:: right-col
 
-    .. code-block:: python3
+    .. rubric:: μSim support of high-level features
+
+    .. code:: python3
 
         >>> from usim import run, time, delay
         >>> async def car():
@@ -224,5 +228,7 @@ Migrating from SimPy to μSim
         ...         await (time + 2)
         ...         print(f'Start parking at {time.now}')
 
-.. _SimPy: https://simpy.readthedocs.io/
-.. _first SimPy example: https://simpy.readthedocs.io/en/latest/simpy_intro/basic_concepts.html
+.. content-tabs:: left-col
+
+    .. _SimPy: https://simpy.readthedocs.io/
+    .. _first SimPy example: https://simpy.readthedocs.io/en/latest/simpy_intro/basic_concepts.html

--- a/docs/source/topics/simpy.rst
+++ b/docs/source/topics/simpy.rst
@@ -1,89 +1,109 @@
 SimPy Compatibility
 ===================
 
-    SimPy_ is a process-based discrete-event simulation framework
-    based on standard Python.
+.. container:: left-col
 
-    --- The SimPy Documentation
+        SimPy_ is a process-based discrete-event simulation framework
+        based on standard Python.
 
-Both μSim and SimPy are discrete, event-based simulation frameworks.
-While SimPy is built on generators and callbacks, μSim relies exclusively
-on the ``async``/``await`` coroutine support introduced in Python 3.5.
-This makes a difference both in the usage, as well as supported features.
+        --- The SimPy Documentation
 
-To allow running, integrating and migrating existing SimPy simulations,
-μSim has an inbuilt compatibility layer: the :py:mod:`usim.py` module
-provides most of the SimPy API. The only truly unsupported feature are scheduling
-priorities - due to its high concurrency, μSim is optimised for FIFO scheduling.
+    Both μSim and SimPy are discrete, event-based simulation frameworks.
+    While SimPy is built on generators and callbacks, μSim relies exclusively
+    on the ``async``/``await`` coroutine support introduced in Python 3.5.
+    This makes a difference both in the usage, as well as supported features.
 
-Using μSim in a SimPy Simulation
---------------------------------
+    To allow running, integrating and migrating existing SimPy simulations,
+    μSim has an inbuilt compatibility layer: the :py:mod:`usim.py` module
+    provides most of the SimPy API. The only truly unsupported feature are scheduling
+    priorities - due to its high concurrency, μSim is optimised for FIFO scheduling.
 
-As :py:mod:`usim.py` replicates the :py:mod:`simpy` API, it is sufficient
-to change imports to ``usim.py`` instead of ``simpy``. If your simulation
-uses the ``simpy`` namespace directly, you can alias ``usim.py`` to ``simpy``.
-Otherwise, import objects from ``usim.py`` instead of ``usim``.
+    Using μSim in a SimPy Simulation
+    --------------------------------
 
-+------------------------------------+--------------------------------------+
-|                                    |                                      |
-| SimPy native imports               | μSim compatibility imports           |
-|                                    |                                      |
-| .. code:: python3                  |  .. code:: python3                   |
-|                                    |                                      |
-|     # module import                |     # alias to expected name         |
-|     import simpy                   |     import usim.py as simpy          |
-|     # object import                |     # import objects                 |
-|     from simpy import Environment  |     from usim.py import Environment  |
-|                                    |                                      |
-+------------------------------------+--------------------------------------+
+    As :py:mod:`usim.py` replicates the :py:mod:`simpy` API, it is sufficient
+    to change imports to ``usim.py`` instead of ``simpy``. If your simulation
+    uses the ``simpy`` namespace directly, you can alias ``usim.py`` to ``simpy``.
+    Otherwise, import objects from ``usim.py`` instead of ``usim``.
 
-Changing imports is all that is required to switch from SimPy to the μSim
-compatibility layer. The core of the `first SimPy example`_ is exactly the
-same for the μSim compatibility layer:
-
-.. content-tabs::
+.. container:: content-tabs right-col
 
     .. tab-container:: usim
         :title: μSim
 
-        .. code:: python3
+        .. rubric:: Compatibility Imports
 
-        >>> def car(env):
-        ...     while True:
-        ...         print('Start parking at %d' % env.now)
-        ...         parking_duration = 5
-        ...         yield env.timeout(parking_duration)
-        ...
-        ...         print('Start driving at %d' % env.now)
-        ...         trip_duration = 2
-        ...         yield env.timeout(trip_duration)
-        ...
+        .. code-block::
+
+            # alias to expected name
+            import usim.py as simpy
+            # import objects
+            from usim.py import Environment
 
     .. tab-container:: simpy
         :title: SimPy
 
-        .. code:: python3
+        .. rubric:: Native Imports
 
-        >>> def car(env):
-        ...     while True:
-        ...         print('Start parking at %d' % env.now)
-        ...         parking_duration = 5
-        ...         yield env.timeout(parking_duration)
-        ...
-        ...         print('Start driving at %d' % env.now)
-        ...         trip_duration = 2
-        ...         yield env.timeout(trip_duration)
-        ...
+        .. code-block::
 
-Running this example is *almost* the same as for SimPy:
-only the single line previously used to ``import simpy`` needs changing.
+            # module import
+            import simpy
+            # object import
+            from simpy import Environment
 
-.. content-tabs::
+.. content-tabs:: left-col
+
+    Changing imports is all that is required to switch from SimPy to the μSim
+    compatibility layer. The core of the `first SimPy example`_ is exactly the
+    same for the μSim compatibility layer:
+
+
+.. content-tabs:: right-col
 
     .. tab-container:: usim
         :title: μSim
 
-        .. code:: python3
+        .. code-block:: python3
+
+            >>> def car(env):
+            ...     while True:
+            ...         print('Start parking at %d' % env.now)
+            ...         parking_duration = 5
+            ...         yield env.timeout(parking_duration)
+            ...
+            ...         print('Start driving at %d' % env.now)
+            ...         trip_duration = 2
+            ...         yield env.timeout(trip_duration)
+            ...
+
+    .. tab-container:: simpy
+        :title: SimPy
+
+        .. code-block:: python3
+
+            >>> def car(env):
+            ...     while True:
+            ...         print('Start parking at %d' % env.now)
+            ...         parking_duration = 5
+            ...         yield env.timeout(parking_duration)
+            ...
+            ...         print('Start driving at %d' % env.now)
+            ...         trip_duration = 2
+            ...         yield env.timeout(trip_duration)
+            ...
+
+.. content-tabs:: left-col
+
+    Running this example is *almost* the same as for SimPy:
+    only the single line previously used to ``import simpy`` needs changing.
+
+.. content-tabs:: right-col
+
+    .. tab-container:: usim
+        :title: μSim
+
+        .. code-block:: python3
 
             >>> import usim.py as simpy  # import usim.py instead of simpy
             >>> env = simpy.Environment()
@@ -99,7 +119,7 @@ only the single line previously used to ``import simpy`` needs changing.
     .. tab-container:: simpy
         :title: SimPy
 
-        .. code:: python3
+        .. code-block:: python3
 
             >>> import simpy
             >>> env = simpy.Environment()
@@ -112,98 +132,100 @@ only the single line previously used to ``import simpy`` needs changing.
             Start driving at 12
             Start parking at 14
 
-The ``usim.py`` layer not only provides the SimPy API, it can even interoperate with native
-μSim simulations. This allows combining simulations from μSim and SimPy, and
-to gradually convert simulations.
+.. content-tabs:: left-col
 
-.. hint::
+    The ``usim.py`` layer not only provides the SimPy API, it can even interoperate with native
+    μSim simulations. This allows combining simulations from μSim and SimPy, and
+    to gradually convert simulations.
 
-    The :py:mod:`usim.py` documentation also describes how compatibility objects
-    can be used directly in native μSim activities.
+    .. hint::
 
-Interactions between μSim and SimPy
------------------------------------
+        The :py:mod:`usim.py` documentation also describes how compatibility objects
+        can be used directly in native μSim activities.
 
-The :py:mod:`usim.py` compatibility layer allows to use SimPy elements in μSim
-and vice versa. This works by translating the fundamental elements of each framework:
+    Interactions between μSim and SimPy
+    -----------------------------------
 
-* a Simpy :py:class:`~usim.py.Event` can be ``await``\ ed in a μSim activity, and
-* a μSim :term:`activity` can be ``yield``\ ed by a SimPy Process.
+    The :py:mod:`usim.py` compatibility layer allows to use SimPy elements in μSim
+    and vice versa. This works by translating the fundamental elements of each framework:
 
-Both approaches *return* the value or *raise* any errors of their activity or event.
-This gives full access to all SimPy features from μSim --
-however, there is no equivalent to μSim's ``async for`` and ``async with`` in SimPy.
+    * a Simpy :py:class:`~usim.py.Event` can be ``await``\ ed in a μSim activity, and
+    * a μSim :term:`activity` can be ``yield``\ ed by a SimPy Process.
 
-.. code:: python3
+    Both approaches *return* the value or *raise* any errors of their activity or event.
+    This gives full access to all SimPy features from μSim --
+    however, there is no equivalent to μSim's ``async for`` and ``async with`` in SimPy.
 
-    >>> from usim import time
-    >>> def car(env):
-    ...     """Partially migrated SimPy process"""
-    ...     trip_duration = 2
-    ...     parking_duration = 5
-    ...     while True:
-    ...         print(f'Start parking at {env.now}')
-    ...         yield (time + parking_duration)
-    ...
-    ...         print(f'Start driving at {env.now}')
-    ...         yield (time + trip_duration)
-    ...
-    >>> import usim.py as simpy  # import usim.py instead of simpy
-    >>> env = simpy.Environment()
-    >>> env.process(car(env))
-    <Process(car) object at 0x...>
-    >>> env.run(until=15)
-    Start parking at 0
-    Start driving at 5
-    Start parking at 7
-    Start driving at 12
-    Start parking at 14
+    .. code:: python3
 
-Note that a :py:class:`~usim.py.Process` may directly ``await`` any :term:`activity`
--- there is no need to wrap an :term:`activity` in another :py:class:`~usim.py.Process`.
-You can use all features of μSim in an :term:`activity`,
-even when it is ``yield``\ ed from a :py:class:`~usim.py.Process`.
+        >>> from usim import time
+        >>> def car(env):
+        ...     """Partially migrated SimPy process"""
+        ...     trip_duration = 2
+        ...     parking_duration = 5
+        ...     while True:
+        ...         print(f'Start parking at {env.now}')
+        ...         yield (time + parking_duration)
+        ...
+        ...         print(f'Start driving at {env.now}')
+        ...         yield (time + trip_duration)
+        ...
+        >>> import usim.py as simpy  # import usim.py instead of simpy
+        >>> env = simpy.Environment()
+        >>> env.process(car(env))
+        <Process(car) object at 0x...>
+        >>> env.run(until=15)
+        Start parking at 0
+        Start driving at 5
+        Start parking at 7
+        Start driving at 12
+        Start parking at 14
 
-Migrating from SimPy to μSim
-----------------------------
+    Note that a :py:class:`~usim.py.Process` may directly ``await`` any :term:`activity`
+    -- there is no need to wrap an :term:`activity` in another :py:class:`~usim.py.Process`.
+    You can use all features of μSim in an :term:`activity`,
+    even when it is ``yield``\ ed from a :py:class:`~usim.py.Process`.
 
-To access the full capabilities of μSim, you should write native μSim simulations.
-Due to the compatibility layer, it is possible to migrate individual pieces.
-The most important difference is that μSim :term:`activities <activity>` are ``async def`` coroutines
-which ``await`` events. In addition, there is no environment that must be passed around
--- all :py:mod:`usim` primitives automatically find their containing simulation.
+    Migrating from SimPy to μSim
+    ----------------------------
 
-.. code:: python3
+    To access the full capabilities of μSim, you should write native μSim simulations.
+    Due to the compatibility layer, it is possible to migrate individual pieces.
+    The most important difference is that μSim :term:`activities <activity>` are ``async def`` coroutines
+    which ``await`` events. In addition, there is no environment that must be passed around
+    -- all :py:mod:`usim` primitives automatically find their containing simulation.
 
-    >>> from usim import run, time
-    >>> async def car():
-    ...     """Fully migrated SimPy process"""
-    ...     while True:
-    ...         print(f'Start parking at {time.now}')
-    ...         await (time + 5)
-    ...         print(f'Start driving at {time.now}')
-    ...         await (time + 2)
-    ...
-    >>> run(car(), till=15)
-    # Start parking at 0
-    # Start driving at 5
-    # Start parking at 7
-    # Start driving at 12
-    # Start parking at 14
+    .. code:: python3
 
-When migrating a SimPy simulation to  μSim, keep in mind that μSim already provides
-many high-level features of simulations.
-For example, μSim's ``async for`` works well to express repetitive tasks:
+        >>> from usim import run, time
+        >>> async def car():
+        ...     """Fully migrated SimPy process"""
+        ...     while True:
+        ...         print(f'Start parking at {time.now}')
+        ...         await (time + 5)
+        ...         print(f'Start driving at {time.now}')
+        ...         await (time + 2)
+        ...
+        >>> run(car(), till=15)
+        # Start parking at 0
+        # Start driving at 5
+        # Start parking at 7
+        # Start driving at 12
+        # Start parking at 14
 
-.. code:: python3
+    When migrating a SimPy simulation to  μSim, keep in mind that μSim already provides
+    many high-level features of simulations.
+    For example, μSim's ``async for`` works well to express repetitive tasks:
 
-    >>> from usim import run, time, delay
-    >>> async def car():
-    ...     print(f'Start parking at {time.now}')
-    ...     async for _ in delay(5):
-    ...         print(f'Start driving at {time.now}')
-    ...         await (time + 2)
-    ...         print(f'Start parking at {time.now}')
+    .. code:: python3
 
-.. _SimPy: https://simpy.readthedocs.io/
-.. _first SimPy example: https://simpy.readthedocs.io/en/latest/simpy_intro/basic_concepts.html
+        >>> from usim import run, time, delay
+        >>> async def car():
+        ...     print(f'Start parking at {time.now}')
+        ...     async for _ in delay(5):
+        ...         print(f'Start driving at {time.now}')
+        ...         await (time + 2)
+        ...         print(f'Start parking at {time.now}')
+
+    .. _SimPy: https://simpy.readthedocs.io/
+    .. _first SimPy example: https://simpy.readthedocs.io/en/latest/simpy_intro/basic_concepts.html

--- a/docs/source/topics/simpy.rst
+++ b/docs/source/topics/simpy.rst
@@ -18,8 +18,10 @@ SimPy Compatibility
     provides most of the SimPy API. The only truly unsupported feature are scheduling
     priorities - due to its high concurrency, μSim is optimised for FIFO scheduling.
 
-    Using μSim in a SimPy Simulation
-    --------------------------------
+Using μSim in a SimPy Simulation
+--------------------------------
+
+.. content-tabs:: left-col
 
     As :py:mod:`usim.py` replicates the :py:mod:`simpy` API, it is sufficient
     to change imports to ``usim.py`` instead of ``simpy``. If your simulation
@@ -56,42 +58,23 @@ SimPy Compatibility
 
     Changing imports is all that is required to switch from SimPy to the μSim
     compatibility layer. The core of the `first SimPy example`_ is exactly the
-    same for the μSim compatibility layer:
+    same for the μSim compatibility layer.
 
 
 .. content-tabs:: right-col
 
-    .. tab-container:: usim
-        :title: μSim
+    .. code-block:: python3
 
-        .. code-block:: python3
-
-            >>> def car(env):
-            ...     while True:
-            ...         print('Start parking at %d' % env.now)
-            ...         parking_duration = 5
-            ...         yield env.timeout(parking_duration)
-            ...
-            ...         print('Start driving at %d' % env.now)
-            ...         trip_duration = 2
-            ...         yield env.timeout(trip_duration)
-            ...
-
-    .. tab-container:: simpy
-        :title: SimPy
-
-        .. code-block:: python3
-
-            >>> def car(env):
-            ...     while True:
-            ...         print('Start parking at %d' % env.now)
-            ...         parking_duration = 5
-            ...         yield env.timeout(parking_duration)
-            ...
-            ...         print('Start driving at %d' % env.now)
-            ...         trip_duration = 2
-            ...         yield env.timeout(trip_duration)
-            ...
+        >>> def car(env):
+        ...     while True:
+        ...         print('Start parking at %d' % env.now)
+        ...         parking_duration = 5
+        ...         yield env.timeout(parking_duration)
+        ...
+        ...         print('Start driving at %d' % env.now)
+        ...         trip_duration = 2
+        ...         yield env.timeout(trip_duration)
+        ...
 
 .. content-tabs:: left-col
 
@@ -143,8 +126,10 @@ SimPy Compatibility
         The :py:mod:`usim.py` documentation also describes how compatibility objects
         can be used directly in native μSim activities.
 
-    Interactions between μSim and SimPy
-    -----------------------------------
+Interactions between μSim and SimPy
+-----------------------------------
+
+.. content-tabs:: left-col
 
     The :py:mod:`usim.py` compatibility layer allows to use SimPy elements in μSim
     and vice versa. This works by translating the fundamental elements of each framework:
@@ -156,7 +141,9 @@ SimPy Compatibility
     This gives full access to all SimPy features from μSim --
     however, there is no equivalent to μSim's ``async for`` and ``async with`` in SimPy.
 
-    .. code:: python3
+.. content-tabs:: right-col
+
+    .. code-block:: python3
 
         >>> from usim import time
         >>> def car(env):
@@ -181,13 +168,17 @@ SimPy Compatibility
         Start driving at 12
         Start parking at 14
 
+.. content-tabs:: left-col
+
     Note that a :py:class:`~usim.py.Process` may directly ``await`` any :term:`activity`
     -- there is no need to wrap an :term:`activity` in another :py:class:`~usim.py.Process`.
     You can use all features of μSim in an :term:`activity`,
     even when it is ``yield``\ ed from a :py:class:`~usim.py.Process`.
 
-    Migrating from SimPy to μSim
-    ----------------------------
+Migrating from SimPy to μSim
+----------------------------
+
+.. content-tabs:: left-col
 
     To access the full capabilities of μSim, you should write native μSim simulations.
     Due to the compatibility layer, it is possible to migrate individual pieces.
@@ -195,7 +186,9 @@ SimPy Compatibility
     which ``await`` events. In addition, there is no environment that must be passed around
     -- all :py:mod:`usim` primitives automatically find their containing simulation.
 
-    .. code:: python3
+.. content-tabs:: right-col
+
+    .. code-block:: python3
 
         >>> from usim import run, time
         >>> async def car():
@@ -213,11 +206,15 @@ SimPy Compatibility
         # Start driving at 12
         # Start parking at 14
 
+.. content-tabs:: left-col
+
     When migrating a SimPy simulation to  μSim, keep in mind that μSim already provides
     many high-level features of simulations.
-    For example, μSim's ``async for`` works well to express repetitive tasks:
+    For example, μSim's ``async for`` works well to express repetitive tasks.
 
-    .. code:: python3
+.. content-tabs:: right-col
+
+    .. code-block:: python3
 
         >>> from usim import run, time, delay
         >>> async def car():
@@ -227,5 +224,5 @@ SimPy Compatibility
         ...         await (time + 2)
         ...         print(f'Start parking at {time.now}')
 
-    .. _SimPy: https://simpy.readthedocs.io/
-    .. _first SimPy example: https://simpy.readthedocs.io/en/latest/simpy_intro/basic_concepts.html
+.. _SimPy: https://simpy.readthedocs.io/
+.. _first SimPy example: https://simpy.readthedocs.io/en/latest/simpy_intro/basic_concepts.html

--- a/docs/source/tutorial/01_activity.rst
+++ b/docs/source/tutorial/01_activity.rst
@@ -1,91 +1,111 @@
 Getting Active
 ==============
 
-.. toctree::
+.. container:: left-col
 
-Simulations in μSim are made from two parts:
-:term:`activities <Activity>` doing things
-and
-:term:`notifications <Notification>` orchestrating things.
-The basics of both are provided by ``usim``,
-but usually you want to build some custom activities.
+    .. toctree::
 
-Activities are implemented as special functions, namely as :term:`coroutines <coroutine>`
-In short, this means you must use ``async def`` instead of just ``def``.
-In return, you can use the special keywords ``await`` and ``async for``/``async with``.
+    Simulations in μSim are made from two parts:
+    :term:`activities <Activity>` doing things
+    and
+    :term:`notifications <Notification>` orchestrating things.
+    The basics of both are provided by ``usim``,
+    but usually you want to build some custom activities.
+
+    Activities are implemented as special functions, namely as :term:`coroutines <coroutine>`
+    In short, this means you must use ``async def`` instead of just ``def``.
+    In return, you can use the special keywords ``await`` and ``async for``/``async with``.
 
 .. _tutorial define activity:
 
 Lesson 01: Defining an Activity
 -------------------------------
 
-In this example, we define our own activity and ``await`` a pre-defined notification.
-Activities are defined using ``async def <name>(<parameters>):``,
-followed by the actions making up the activity.
-We use ``usim.time`` to track and receive notifications about the progression of time in our simulation.
+.. content-tabs:: left-col
 
-.. code:: python3
+    In this example, we define our own activity and ``await`` a pre-defined notification.
+    Activities are defined using ``async def <name>(<parameters>):``,
+    followed by the actions making up the activity.
+    We use ``usim.time`` to track and receive notifications about the progression of time in our simulation.
 
-    >>> from usim import time
-    >>>
-    >>> async def drink(beverage='coffee', duration=20):       # 1
-    ...     print('Start drinking', beverage, 'at', time.now)  # 2
-    ...     await (time + duration)                            # 3
-    ...     print('Stop drinking', beverage, 'at', time.now)
+.. container:: content-tabs right-col
 
-For the most part, activities are regular functions.
-Take a look at how our activity compares to other functions:
+    .. code:: python3
 
-1. Activities *must* be defined using ``async def`` - this allows us to suspend and resume activities.
-   μSim *does not* require a specific signature, however.
-   You are free to use any parameters that you see fit.
+        >>> from usim import time
+        >>>
+        >>> async def drink(beverage='coffee', duration=20):       # 1
+        ...     print('Start drinking', beverage, 'at', time.now)  # 2
+        ...     await (time + duration)                            # 3
+        ...     print('Stop drinking', beverage, 'at', time.now)
 
-2. You can freely call other functions, such as ``print``.
-   All non-suspending features of μSim, such as ``time.now``, behave like regular objects and functions.
+.. content-tabs:: left-col
 
-3. Activities can be suspended and resumed on notification using ``await``.
-   You can construct notifications regularly, such as ``time + duration`` marking a point in the future.
+    For the most part, activities are regular functions.
+    Take a look at how our activity compares to other functions:
 
-The takeaway is that you use ``async``/``await`` when you need activities suspended/resumed on notifications.
-For everything else, such as querying the simulation state, you do not need to take special actions.
+    1. Activities *must* be defined using ``async def`` - this allows us to suspend and resume activities.
+       μSim *does not* require a specific signature, however.
+       You are free to use any parameters that you see fit.
+
+    2. You can freely call other functions, such as ``print``.
+       All non-suspending features of μSim, such as ``time.now``, behave like regular objects and functions.
+
+    3. Activities can be suspended and resumed on notification using ``await``.
+       You can construct notifications regularly, such as ``time + duration`` marking a point in the future.
+
+    The takeaway is that you use ``async``/``await`` when you need activities suspended/resumed on notifications.
+    For everything else, such as querying the simulation state, you do not need to take special actions.
 
 Epilogue 01: Running an Activity
 --------------------------------
 
-With our activity defined, we can now use it as our first, small simulation!
-Any activity must be instantiated by calling it;
-this allows to fill in parameters and re-use activities.
-In order to run it, we pass the instantiated activity to ``usim.run``:
+.. content-tabs:: left-col
 
-.. code:: python3
+    With our activity defined, we can now use it as our first, small simulation!
+    Any activity must be instantiated by calling it;
+    this allows to fill in parameters and re-use activities.
+    In order to run it, we pass the instantiated activity to ``usim.run``.
 
-    >>> from usim import run
-    >>>
-    >>> drink_coffee = drink()  # instantiate activity
-    >>> run(drink_coffee)       # run the activity instance
-    Start drinking coffee at 0
-    Stop drinking coffee at 20
+.. content-tabs:: right-col
 
-By calling ``usim.run``, we start the simulation at the *root activities* passed in.
-μSim can handle multiple root activities;
-they are started in :term:`turn` but at the same simulation :term:`time`.
-For example, we can use our activity several times:
+    .. code:: python3
 
-.. code:: python3
+        >>> from usim import run
+        >>>
+        >>> drink_coffee = drink()  # instantiate activity
+        >>> run(drink_coffee)       # run the activity instance
+        Start drinking coffee at 0
+        Stop drinking coffee at 20
 
-    >>> run(drink(), drink('tea', 30), drink('water', 5))
-    Start drinking coffee at 0
-    Start drinking tea at 0
-    Start drinking water at 0
-    Done drinking water at 5
-    Done drinking coffee at 20
-    Done drinking tea at 30
+.. content-tabs:: left-col
 
-As activities ``await`` notifications, activities are interleaved as if time would pass for real.
-By using the helpers of μSim, such as ``usim.time``, your activities naturally have the correct notifications.
+    By calling ``usim.run``, we start the simulation at the *root activities* passed in.
+    μSim can handle multiple root activities;
+    they are started in :term:`turn` but at the same simulation :term:`time`.
+    For example, we can use our activity several times.
+
+.. content-tabs:: right-col
+
+    .. code:: python3
+
+        >>> run(drink(), drink('tea', 30), drink('water', 5))
+        Start drinking coffee at 0
+        Start drinking tea at 0
+        Start drinking water at 0
+        Done drinking water at 5
+        Done drinking coffee at 20
+        Done drinking tea at 30
+
+.. content-tabs:: left-col
+
+    As activities ``await`` notifications, activities are interleaved as if time would pass for real.
+    By using the helpers of μSim, such as ``usim.time``, your activities naturally have the correct notifications.
 
 Let's do more things...
 -----------------------
 
-So far, we have just started a fixed set of activities.
-Head over to the :doc:`next section <./02_stacked>` to combine several activities.
+.. content-tabs:: left-col
+
+    So far, we have just started a fixed set of activities.
+    Head over to the :doc:`next section <./02_stacked>` to combine several activities.

--- a/docs/source/tutorial/02_stacked.rst
+++ b/docs/source/tutorial/02_stacked.rst
@@ -1,69 +1,83 @@
 Raise the Stacks
 ================
 
-As simulations grow, it is good practice to separate them into distinct parts.
-The primary means is to construct complex activities from other, simpler activities.
-When using ``usim``, there is no distinction between combining pre-made and custom activities.
+.. container:: left-col
 
-Activities can be used like notifications in other activities.
-You can ``await`` the completion of an activity just like a notification.
-This allows to stack activities, and combine them to create complex constructs.
+    As simulations grow, it is good practice to separate them into distinct parts.
+    The primary means is to construct complex activities from other, simpler activities.
+    When using ``usim``, there is no distinction between combining pre-made and custom activities.
+
+    Activities can be used like notifications in other activities.
+    You can ``await`` the completion of an activity just like a notification.
+    This allows to stack activities, and combine them to create complex constructs.
 
 Interlude 01: Combining Activities
 ----------------------------------
 
-This example is similar to our `previous lesson <tutorial define activity>`_,
-but with an additional activity.
-Each activity separately uses ``usim`` to delay for some time.
-However, we use ``await`` and ``return`` to compose them to a single action.
+.. content-tabs:: left-col
 
-.. code:: python3
+    This example is similar to our `previous lesson <tutorial define activity>`_,
+    but with an additional activity.
+    Each activity separately uses ``usim`` to delay for some time.
+    However, we use ``await`` and ``return`` to compose them to a single action.
 
-    >>> from usim import time
-    >>>
-    >>> async def refill(beverage):                           #1
-    ...     print('Start filling', beverage, 'at', time.now)
-    ...     await (time + 5)
-    ...     print('Stop filling', beverage, 'at', time.now)
-    ...     return 5                                          #2
-    ...
-    >>> async def drink(beverage='coffee', duration=20):
-    ...     refill_duration = await refill(beverage)          #3
-    ...     print('Refill took', refill_duration)
-    ...     print('Start drinking', beverage, 'at', time.now)
-    ...     await (time + duration)
-    ...     print('Stop drinking', beverage, 'at', time.now)
+.. container:: content-tabs right-col
 
-Both activities extend the same basic template as used earlier.
-Take note how our activities interact with each other:
+    .. code:: python3
 
-1. Like root activities, nested activities do not need to accept some simulation state or environment.
-   You can focus on the parameters that matter for the activity at hand.
+        >>> from usim import time
+        >>>
+        >>> async def refill(beverage):                           #1
+        ...     print('Start filling', beverage, 'at', time.now)
+        ...     await (time + 5)
+        ...     print('Stop filling', beverage, 'at', time.now)
+        ...     return 5                                          #2
+        ...
+        >>> async def drink(beverage='coffee', duration=20):
+        ...     refill_duration = await refill(beverage)          #3
+        ...     print('Refill took', refill_duration)
+        ...     print('Start drinking', beverage, 'at', time.now)
+        ...     await (time + duration)
+        ...     print('Stop drinking', beverage, 'at', time.now)
 
-2. Nested activities may ``return`` values. [#activityreturn]_
-   This works just like regular functions returning values, and ends the activity.
+.. content-tabs:: left-col
 
-3. Activities may ``await`` other activities.
-   This suspends the outer activity until the inner activity finishes.
-   The result of ``await`` is the ``return`` value of the inner activity.
+    Both activities extend the same basic template as used earlier.
+    Take note how our activities interact with each other:
 
-The takeaway is that ``await`` and ``return`` allow you to combine activities.
-Splitting your activities into smaller parts is important to build large and complex simulations.
+    1. Like root activities, nested activities do not need to accept some simulation state or environment.
+       You can focus on the parameters that matter for the activity at hand.
 
-    >>> from usim import run
-    >>>
-    >>> run(drink('tea', duration=40))   # run the root activity
-    Start filling tea at 0
-    Stop filling tea at 5
-    Refill took 5
-    Start drinking tea at 5
-    Stop drinking tea at 45
+    2. Nested activities may ``return`` values. [#activityreturn]_
+       This works just like regular functions returning values, and ends the activity.
+
+    3. Activities may ``await`` other activities.
+       This suspends the outer activity until the inner activity finishes.
+       The result of ``await`` is the ``return`` value of the inner activity.
+
+    The takeaway is that ``await`` and ``return`` allow you to combine activities.
+    Splitting your activities into smaller parts is important to build large and complex simulations.
+
+.. content-tabs:: right-col
+
+    .. code:: python3
+
+        >>> from usim import run
+        >>>
+        >>> run(drink('tea', duration=40))   # run the root activity
+        Start filling tea at 0
+        Stop filling tea at 5
+        Refill took 5
+        Start drinking tea at 5
+        Stop drinking tea at 45
 
 Let's do many things...
 -----------------------
 
-So far, we have just run a fixed number of activities.
-Head over to the :doc:`next section <./03_scopes>` to write branching activities.
+.. content-tabs:: left-col
 
-.. [#activityreturn] It is a common mistake in concurrent programming to accidentally forget about return values.
-                     μSim thus considers it an error if activities ``return`` something that is never received.
+    So far, we have just run a fixed number of activities.
+    Head over to the :doc:`next section <./03_scopes>` to write branching activities.
+
+    .. [#activityreturn] It is a common mistake in concurrent programming to accidentally forget about return values.
+                         μSim thus considers it an error if activities ``return`` something that is never received.

--- a/docs/source/tutorial/03_scopes.rst
+++ b/docs/source/tutorial/03_scopes.rst
@@ -1,84 +1,96 @@
 Branch Out
 ==========
 
-Many simulations need additional, concurrent activities in addition to their initial activities.
-However, concurrent programming is error-prone when actions are separated from each other.
-To handle this safely, μSim requires existing activities to branch out only temporarily.
+.. container:: left-col
 
-Activities may branch out only after defining a scope of concurrency.
-The most basic scope is opened by entering an ``async with Scope()`` context.
-In turn, a scope may ``do`` several activities at once while it is active.
+    Many simulations need additional, concurrent activities in addition to their initial activities.
+    However, concurrent programming is error-prone when actions are separated from each other.
+    To handle this safely, μSim requires existing activities to branch out only temporarily.
+
+    Activities may branch out only after defining a scope of concurrency.
+    The most basic scope is opened by entering an ``async with Scope()`` context.
+    In turn, a scope may ``do`` several activities at once while it is active.
 
 .. _tutorial basic scope:
 
 Lesson 02: Using a Concurrent Scope
 -----------------------------------
 
-In this example, we define an activity that uses a ``Scope`` to concurrently run another activity several times.
-Scopes are opened using ````async with Scope() as <name>:``,
-followed by a block of actions which it covers. [#blockscope]_
-We again use ``usim.time`` to track and influence the progression of our simulation.
+.. content-tabs:: left-col
 
-.. code:: python3
+    In this example, we define an activity that uses a ``Scope`` to concurrently run another activity several times.
+    Scopes are opened using ````async with Scope() as <name>:``,
+    followed by a block of actions which it covers. [#blockscope]_
+    We again use ``usim.time`` to track and influence the progression of our simulation.
 
-    >>> from usim import time, Scope
-    >>>
-    >>> async def deliver_one(which):
-    ...     print('Delivering', which, 'at', time.now)
-    ...     await (time + 5)
-    ...     print('Delivered', which, 'at', time.now)
-    ...
-    >>> async def deliver_all():
-    ...     print('-- Start deliveries at', time.now)
-    ...     async with Scope() as drivers:             # 1
-    ...         drivers.do(deliver_one(1))             # 2
-    ...         drivers.do(deliver_one(2))
-    ...         await (time + 1)                       # 3
-    ...         drivers.do(deliver_one(3))
-    ...         print('Sent deliveries at', time.now)  # 4.1
-    ...     print('-- Done deliveries at', time.now)   # 4.2
+.. container:: content-tabs right-col
 
-Scopes can be difficult because they are inherently about doing several things at once.
-It helps to step through individual points of notice:
+    .. code:: python3
 
-1. A scope must always be opened as an ``async with`` context - this allows us to suspend and resume
-   branched off activities.
-   You can freely choose a name; we recommend a name that reflects your simulation story.
+        >>> from usim import time, Scope
+        >>>
+        >>> async def deliver_one(which):
+        ...     print('Delivering', which, 'at', time.now)
+        ...     await (time + 5)
+        ...     print('Delivered', which, 'at', time.now)
+        ...
+        >>> async def deliver_all():
+        ...     print('-- Start deliveries at', time.now)
+        ...     async with Scope() as drivers:             # 1
+        ...         drivers.do(deliver_one(1))             # 2
+        ...         drivers.do(deliver_one(2))
+        ...         await (time + 1)                       # 3
+        ...         drivers.do(deliver_one(3))
+        ...         print('Sent deliveries at', time.now)  # 4.1
+        ...     print('-- Done deliveries at', time.now)   # 4.2
 
-2. Activities are branched off using ``scope.do(activity)`` in place of ``await activity``.
-   The current activity does *not* wait for the branched off activity to start or finish at this point.
+.. content-tabs:: left-col
 
-3. The current activity is free to perform other actions inside a scope.
-   This includes calling functions and ``await``\ ing notifications,
-   or using loops/functions to create more activities to do.
+    Scopes can be difficult because they are inherently about doing several things at once.
+    It helps to step through individual points of notice:
 
-4. Transitioning out of a scope is delayed until all branched off activities have finished. [#volatile]_
-   Statements directly before and after the end of scope do not happen in the same :term:`turn`.
+    1. A scope must always be opened as an ``async with`` context - this allows us to suspend and resume
+       branched off activities.
+       You can freely choose a name; we recommend a name that reflects your simulation story.
 
-The primary purpose of scopes is to keep concurrent activities comprehensible.
+    2. Activities are branched off using ``scope.do(activity)`` in place of ``await activity``.
+       The current activity does *not* wait for the branched off activity to start or finish at this point.
 
-.. code:: python3
+    3. The current activity is free to perform other actions inside a scope.
+       This includes calling functions and ``await``\ ing notifications,
+       or using loops/functions to create more activities to do.
 
-    >>> from usim import run
-    >>>
-    >>> run(deliver_all())
-    -- Start deliveries at 0
-    Delivering 1 at 0
-    Delivering 2 at 0
-    Sent deliveries at 1
-    Delivering 3 at 1
-    Delivered 1 at 5
-    Delivered 2 at 5
-    Delivered 3 at 6
-    -- Done deliveries at 6
+    4. Transitioning out of a scope is delayed until all branched off activities have finished. [#volatile]_
+       Statements directly before and after the end of scope do not happen in the same :term:`turn`.
+
+    The primary purpose of scopes is to keep concurrent activities comprehensible.
+
+.. content-tabs:: right-col
+
+    .. code:: python3
+
+        >>> from usim import run
+        >>>
+        >>> run(deliver_all())
+        -- Start deliveries at 0
+        Delivering 1 at 0
+        Delivering 2 at 0
+        Sent deliveries at 1
+        Delivering 3 at 1
+        Delivered 1 at 5
+        Delivered 2 at 5
+        Delivered 3 at 6
+        -- Done deliveries at 6
 
 Let's take a step back...
 -------------------------
 
-So far, we have just run all activities to completion.
-Head over to the :doc:`next section <./04_cancel_scope>` to cancel activities and notifications.
+.. content-tabs:: left-col
 
-.. [#blockscope] Notably, the block of the scope may contain other blocks and call out to functions.
-                 The scope applies to all of them, and can be passed down to functions if needed.
+    So far, we have just run all activities to completion.
+    Head over to the :doc:`next section <./04_cancel_scope>` to cancel activities and notifications.
 
-.. [#volatile] The exception are ``volatile`` activities.
+    .. [#blockscope] Notably, the block of the scope may contain other blocks and call out to functions.
+                     The scope applies to all of them, and can be passed down to functions if needed.
+
+    .. [#volatile] The exception are ``volatile`` activities.

--- a/docs/source/tutorial/overview.rst
+++ b/docs/source/tutorial/overview.rst
@@ -1,100 +1,128 @@
 Brief Tour to μSim
 ==================
 
-This is a short tutorial to using μSim to create your own simulation.
-Teaching by example, the tutorial will get you started quickly.
-It provides an overview of how to best use all tools provided by μSim.
-If needed, additional information is directly accessible from each section.
+.. container:: left-col
 
-If you are already familiar with Python, install ``usim`` and head straight to the :doc:`first section <./01_activity>`.
-Otherwise, proceed below for a short introduction to install μSim and launch Python.
+    This is a short tutorial to using μSim to create your own simulation.
+    Teaching by example, the tutorial will get you started quickly.
+    It provides an overview of how to best use all tools provided by μSim.
+    If needed, additional information is directly accessible from each section.
 
-.. toctree::
-    :maxdepth: 1
+    If you are already familiar with Python, install ``usim`` and head straight to the :doc:`first section <./01_activity>`.
+    Otherwise, proceed below for a short introduction to install μSim and launch Python.
 
-    01_activity
-    02_stacked
-    03_scopes
+    .. toctree::
+        :maxdepth: 1
+
+        01_activity
+        02_stacked
+        03_scopes
 
 Installing μSim
 ---------------
 
-The newest version of μSim is readily available via Python's package manager.
-You only need Python 3.5 or newer to get started:
+.. content-tabs:: left-col
 
-.. code:: bash
+    The newest version of μSim is readily available via Python's package manager.
+    You only need Python 3.5 or newer to get started.
 
-    python3 -m pip install usim
+.. container:: content-tabs right-col
 
-This takes care of installing μSim (the ``usim`` package) and any dependencies. [#pypy3]_
+    .. code:: bash
+
+        python3 -m pip install usim
+
+.. content-tabs:: left-col
+
+    This takes care of installing μSim (the ``usim`` package) and any dependencies. [#pypy3]_
 
 Interactive or Scripted
 -----------------------
 
-You can use μSim both from an interactive Python shell, or a Python script.
-A shell makes it easier to develop and experiment; a script simplifies reuse and reproducibility.
-However, you can freely switch between the two as you prefer.
-The only difference is whether you write code to the shell or a file!
+.. container:: left-col
+
+    You can use μSim both from an interactive Python shell, or a Python script.
+    A shell makes it easier to develop and experiment; a script simplifies reuse and reproducibility.
+    However, you can freely switch between the two as you prefer.
+    The only difference is whether you write code to the shell or a file!
 
 The Shell
 .........
 
-Python already ships with a basic interactive shell.
-It can be launched from a terminal by typing ``python3``.
-Simply enter the code as desired - but make sure to indent it properly!
-The shell automatically executes any line that is a completed statement, or asks for more with ``...``:
+.. content-tabs:: left-col
 
-.. code:: python3
+    Python already ships with a basic interactive shell.
+    It can be launched from a terminal by typing ``python3``.
+    Simply enter the code as desired - but make sure to indent it properly!
+    The shell automatically executes any line that is a completed statement, or asks for more with ``...``:
 
-    $ python3
-    Python 3.7.0 (default, Sep 14 2018, 16:24:12)
-    [Clang 9.0.0 (clang-900.0.39.2)] on darwin
-    Type "help", "copyright", "credits" or "license" for more information.
-    >>> # insert your code after >>> or ...
-    >>> from usim import run, time
-    >>>
-    >>> print('usim version:', usim.__version__)
-    usim version: 0.1.0
-    >>>
+.. content-tabs:: right-col
 
-There are various advanced shells available that make your life easier.
-For example, ``ipython3`` offers code completion, help messages and other convenience features. [#ipython]_
+    .. code:: python3
+
+        $ python3
+        Python 3.7.0 (default, Sep 14 2018, 16:24:12)
+        [Clang 9.0.0 (clang-900.0.39.2)] on darwin
+        Type "help", "copyright", "credits" or "license" for more information.
+        >>> # insert your code after >>> or ...
+        >>> from usim import run, time
+        >>>
+        >>> print('usim version:', usim.__version__)
+        usim version: 0.1.0
+        >>>
+
+.. content-tabs:: left-col
+
+    There are various advanced shells available that make your life easier.
+    For example, ``ipython3`` offers code completion, help messages and other convenience features. [#ipython]_
 
 Scripting
 .........
 
-Python can directly execute code from files.
-Simply open a file and write your code inside;
-any text editor is suitable for small scripts.
-Note that no code is executed at this time.
+.. content-tabs:: left-col
 
-.. code:: python3
+    Python can directly execute code from files.
+    Simply open a file and write your code inside;
+    any text editor is suitable for small scripts.
+    Note that no code is executed at this time.
 
-    # my_script.py
-    from usim import run, time
+.. content-tabs:: right-col
 
-    print('usim version:', usim.__version__)
+    .. code:: python3
 
-To run an existing script from a terminal,
-execute Python with the path of the script.
+        # my_script.py
+        from usim import run, time
 
-.. code:: bash
+        print('usim version:', usim.__version__)
 
-    $ python3 my_script.py
-    usim version: 0.1.0
+.. content-tabs:: left-col
 
-As your simulations become more complex,
-scripts allow you to re-run and fine-tune your work.
-Various advanced text editors and IDEs are available
-to help you write correct and maintainable code.
+    To run an existing script from a terminal,
+    execute Python with the path of the script.
+
+.. content-tabs:: right-col
+
+    .. code:: bash
+
+        $ python3 my_script.py
+        usim version: 0.1.0
+
+.. content-tabs:: left-col
+
+    As your simulations become more complex,
+    scripts allow you to re-run and fine-tune your work.
+    Various advanced text editors and IDEs are available
+    to help you write correct and maintainable code.
 
 Let's get started...
 --------------------
 
-You now have Python and μSim ready to get started.
-Head over to the :doc:`next section <./01_activity>` to write your first simulation.
+.. content-tabs:: left-col
 
-.. [#pypy3] Note that μSim does not require any non-Python dependencies.
-            It is fully compatible and tested with PyPy3 as well, if you need more speed.
+    You now have Python and μSim ready to get started.
+    Head over to the :doc:`next section <./01_activity>` to write your first simulation.
 
-.. [#ipython] Install it by executing ``python3 -m pip install ipython``.
+    .. [#pypy3] Note that μSim does not require any non-Python dependencies.
+                It is fully compatible and tested with PyPy3 as well, if you need more speed.
+
+    .. [#ipython] Install it by executing ``python3 -m pip install ipython``.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ if __name__ == '__main__':
             'sortedcontainers',
         ],
         extras_require={
-            'docs': ["sphinx", "sphinx_rtd_theme", "sphinxcontrib-trio"],
+            'docs': ["sphinx", "sphinx_rtd_theme", "sphinxcontrib-trio",
+                     "sphinxcontrib-contentui"],
             'test': TESTS_REQUIRE,
             'contrib': ['flake8', 'flake8-bugbear'] + TESTS_REQUIRE,
         },


### PR DESCRIPTION
Aim of this Pull Request is to introduce a two-column layout for the documentation. 
This PR follows the following formatting guidelines:

* regular descriptions go into the left column,
* code examples and commands go into the right column,
* note and hint boxes go into the right column,
* if possible, direct comparisons e.g. usim/SimPy should use a tabbed layout.