### PR TITLE
Scope child cleanup

### DIFF
--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -222,13 +222,13 @@ class Scope:
     def _close_children(self):
         """Forcefully close all child non-volatile tasks"""
         reason = TaskClosed("closed at end of scope '%s'" % self)
-        for child in self._children:
+        for child in self._children.copy():
             child.__close__(reason=reason)
 
     def _close_volatile(self):
         """Forcefully close all volatile child tasks"""
         reason = VolatileTaskClosed("closed at end of scope '%s'" % self)
-        for child in self._volatile_children:
+        for child in self._volatile_children.copy():
             child.__close__(reason=reason)
 
     async def __aenter__(self):

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -211,3 +211,17 @@ class TestScoping:
         with pytest.raises(RuntimeError):
             scope.do(payload)
         assert inspect.getcoroutinestate(payload) == inspect.CORO_CLOSED
+
+    @via_usim
+    async def test_close_volatile(self):
+        """All volatile children are closed at end of scope"""
+        async def activity():
+            await (time + 10)
+
+        async with Scope() as scope:
+            volatile_children = [scope.do(activity(), volatile=True) for _ in range(5)]
+            for child in volatile_children:
+                assert not child.done
+        assert (time == 0)
+        for child in volatile_children:
+            assert child.done


### PR DESCRIPTION
This pull request fixes an issue when closing children of a Scope. An implicit deletion during iteration caused every second child to be skipped.