### PR TITLE
Concurrent exception cascade

### DIFF
--- a/docs/source/topics/exceptions.rst
+++ b/docs/source/topics/exceptions.rst
@@ -201,6 +201,28 @@ Handling Multiple Exceptions
     Finally, we recommend using ``Concurrent[...]`` only if you want to suppress
     concurrent exceptions unconditionally.
 
+Propagating Exceptions Best-Practices
+-------------------------------------
+
+.. content-tabs:: left-col
+
+    Whether an :term:`activity` uses concurrency or not is usually not obvious.
+    Unless explicitly documented, a :py:exc:`~usim.Concurrent` exception propagating
+    out of an :term:`activity` is likely unexpected.
+    As such, avoid propagating :py:exc:`~usim.Concurrent` exceptions whenever possible!
+
+    All abstractions in μSim convert internal :py:exc:`~usim.Concurrent` exceptions
+    to regular exceptions.
+    Only :py:class:`~usim.Scope` and derived types may raise
+    :py:exc:`~usim.Concurrent` exceptions when exiting an ``async with`` context.
+    The intention is to hide implementation details,
+    while allowing full control on expected concurrency.
+
+    We strongly recommend to similarly avoid propagating
+    :py:exc:`~usim.Concurrent` exceptions if possible.
+    When unavoidable, do not expose nested concurrency but
+    propagate a :py:meth:`~usim.Concurrent.flattened` exception if necessary.
+
 
     .. [#debug] For the use of :py:exc:`AssertionError` by μSim,
                 see also :doc:`./debug`.

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -157,15 +157,19 @@ class MetaConcurrent(type):
             return cls
         # Cls[item]
         elif type(item) is not tuple:
-            assert issubclass(item, (Exception, cls)),\
-                f'{cls.__name__!r} may only be specialised by Exception subclasses'
+            assert issubclass(item, (Exception, cls)), (
+                f'{cls.__name__!r} may only be specialised by Exception subclasses, '
+                f'not {item}'
+            )
             item = (item,)
         # Cls[item1, item2]
         else:
             assert all(
                 (child is ...) or issubclass(child, (Exception, cls)) for child in item
-            ),\
-                f'{cls.__name__!r} may only be specialised by Exception subclasses'
+            ), (
+                f'{cls.__name__!r} may only be specialised by Exception subclasses, '
+                f'not {item}'
+            )
         return cls._get_specialisation(item)
 
     def _get_specialisation(cls, item):
@@ -182,9 +186,12 @@ class MetaConcurrent(type):
         except KeyError:
             inclusive = ... in unique_spec
             specialisations = tuple(child for child in unique_spec if child is not ...)
-            spec = ", ".join(  # the specialisation string "KeyError, IndexError, ..."
+            # the specialisation string "KeyError, IndexError, ..."
+            spec = ", ".join(
                 child.__name__ for child in specialisations
             ) + (', ...' if inclusive else '')
+            # the specialised subclass, as in
+            #
             # class 'cls.__name__[spec]'(cls, specialisations, inclusive):
             #   pass
             #

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -327,7 +327,7 @@ class Concurrent(BaseException, metaclass=MetaConcurrent):
         For example, flattening a ``Concurrent(Concurrent(KeyError()), IndexError())``
         provides a ``Concurrent(KeyError(), IndexError())``.
         """
-        if not self.__specialisations__:
+        if not any(isinstance(exc, Concurrent) for exc in self.children):
             return self
         leaves = []
         for child in self.children:

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -326,7 +326,7 @@ class Concurrent(BaseException, metaclass=MetaConcurrent):
         For example, flattening a ``Concurrent(Concurrent(KeyError()), IndexError())``
         provides a ``Concurrent(KeyError(), IndexError())``.
         """
-        if Concurrent not in self.__specialisations__:
+        if not self.__specialisations__:
             return self
         leaves = []
         for child in self.children:

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -329,13 +329,13 @@ class Concurrent(BaseException, metaclass=MetaConcurrent):
         """
         if not any(isinstance(exc, Concurrent) for exc in self.children):
             return self
-        leaves = []
+        leafs = []
         for child in self.children:
             if isinstance(child, Concurrent):
-                leaves.extend(child.flattened().children)
+                leafs.extend(child.flattened().children)
             else:
-                leaves.append(child)
-        flat = Concurrent(*leaves)
+                leafs.append(child)
+        flat = Concurrent(*leafs)
         flat.__cause__ = self.__cause__
         flat.__context__ = self.__context__
         return flat

--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -157,13 +157,13 @@ class MetaConcurrent(type):
             return cls
         # Cls[item]
         elif type(item) is not tuple:
-            assert issubclass(item, Exception),\
+            assert issubclass(item, (Exception, cls)),\
                 f'{cls.__name__!r} may only be specialised by Exception subclasses'
             item = (item,)
         # Cls[item1, item2]
         else:
             assert all(
-                (child is ...) or issubclass(child, Exception) for child in item
+                (child is ...) or issubclass(child, (Exception, cls)) for child in item
             ),\
                 f'{cls.__name__!r} may only be specialised by Exception subclasses'
         return cls._get_specialisation(item)

--- a/usim_pytest/test_types/test_concurrent_exception.py
+++ b/usim_pytest/test_types/test_concurrent_exception.py
@@ -10,6 +10,11 @@ class FakeConcurrent:
 
 class TestConcurrent:
     """Test the semantics of ``usim.Concurrent``"""
+    def test_misuse(self):
+        base_case = Concurrent[KeyError]
+        with pytest.raises(TypeError):
+            base_case[IndexError]
+
     def test_generic(self):
         """Generic ``Concurrent`` is a catch-all"""
         with pytest.raises(Concurrent):
@@ -128,6 +133,7 @@ class TestConcurrent:
         )
 
     def test_flattened_type(self):
+        """Flattening ``Concurrent[[Concurrent[a], b, ...]`` type-checks to flat case"""
         assert issubclass(
             type(Concurrent(Concurrent(KeyError())).flattened()), Concurrent[KeyError]
         )
@@ -152,6 +158,7 @@ class TestConcurrent:
         )
 
     def test_unflattend_type(self):
+        """Unflattened ``Concurrent[[Concurrent[a], b, ...]`` type-checks precisely"""
         assert issubclass(
             type(Concurrent(Concurrent(KeyError()))), Concurrent[Concurrent[KeyError]]
         )

--- a/usim_pytest/test_types/test_concurrent_exception.py
+++ b/usim_pytest/test_types/test_concurrent_exception.py
@@ -144,6 +144,23 @@ class TestConcurrent:
             Concurrent[LookupError, IndexError]
         )
 
+    def test_unflattend_type(self):
+        assert issubclass(
+            type(Concurrent(Concurrent(KeyError()))), Concurrent[Concurrent[KeyError]]
+        )
+        assert issubclass(
+            type(Concurrent(Concurrent(KeyError()), KeyError())),
+            Concurrent[Concurrent[KeyError], KeyError]
+        )
+        assert issubclass(
+            type(Concurrent(Concurrent(KeyError()), IndexError())),
+            Concurrent[Concurrent[KeyError], IndexError]
+        )
+        assert issubclass(
+            type(Concurrent(Concurrent(LookupError()), IndexError())),
+            Concurrent[Concurrent[LookupError], IndexError]
+        )
+
     def test_flattened_value(self):
         children = KeyError(), KeyError(), IndexError()
         assert Concurrent(

--- a/usim_pytest/test_types/test_concurrent_exception.py
+++ b/usim_pytest/test_types/test_concurrent_exception.py
@@ -143,6 +143,13 @@ class TestConcurrent:
             type(Concurrent(Concurrent(LookupError()), IndexError()).flattened()),
             Concurrent[LookupError, IndexError]
         )
+        assert issubclass(
+            type(Concurrent(KeyError()).flattened()), Concurrent[KeyError]
+        )
+        assert issubclass(
+            type(Concurrent(Concurrent(KeyError())).flattened().flattened()),
+            Concurrent[KeyError],
+        )
 
     def test_unflattend_type(self):
         assert issubclass(

--- a/usim_pytest/test_types/test_concurrent_exception.py
+++ b/usim_pytest/test_types/test_concurrent_exception.py
@@ -126,3 +126,26 @@ class TestConcurrent:
         assert not issubclass(
             Concurrent[KeyError, LookupError], Concurrent[KeyError, RuntimeError]
         )
+
+    def test_flattened_type(self):
+        assert issubclass(
+            type(Concurrent(Concurrent(KeyError())).flattened()), Concurrent[KeyError]
+        )
+        assert issubclass(
+            type(Concurrent(Concurrent(KeyError()), KeyError()).flattened()),
+            Concurrent[KeyError]
+        )
+        assert issubclass(
+            type(Concurrent(Concurrent(KeyError()), IndexError()).flattened()),
+            Concurrent[KeyError, IndexError]
+        )
+        assert issubclass(
+            type(Concurrent(Concurrent(LookupError()), IndexError()).flattened()),
+            Concurrent[LookupError, IndexError]
+        )
+
+    def test_flattened_value(self):
+        children = KeyError(), KeyError(), IndexError()
+        assert Concurrent(
+            Concurrent(children[0]), *children[1:]
+        ).flattened().children == children

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -140,11 +140,17 @@ class TestExceptions:
 
     @via_usim
     async def test_fail_nested(self):
+        """Nested failures may be handled"""
         async def inner_raise(exc: BaseException):
             async with Scope() as scope:
                 scope.do(async_raise(exc))
 
+        # raising is valid
         with pytest.raises(Concurrent):
+            async with Scope() as scope:
+                scope.do(inner_raise(KeyError()))
+        # handling is valid
+        with pytest.raises(Concurrent[Concurrent[KeyError]]):
             async with Scope() as scope:
                 scope.do(inner_raise(KeyError()))
 

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -138,6 +138,16 @@ class TestExceptions:
                     scope.do(async_raise(KeyError(), 0))
                     raise exc_type
 
+    @via_usim
+    async def test_fail_nested(self):
+        async def inner_raise(exc: BaseException):
+            async with Scope() as scope:
+                scope.do(async_raise(exc))
+
+        with pytest.raises(Concurrent):
+            async with Scope() as scope:
+                scope.do(inner_raise(KeyError()))
+
 
 class TestScoping:
     @via_usim

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -153,6 +153,16 @@ class TestExceptions:
         with pytest.raises(Concurrent[Concurrent[KeyError]]):
             async with Scope() as scope:
                 scope.do(inner_raise(KeyError()))
+        with pytest.raises(Concurrent[Concurrent]):
+            async with Scope() as scope:
+                scope.do(inner_raise(KeyError()))
+        with pytest.raises(Concurrent[Concurrent]):
+            # this layer is expected to let the exception pass through
+            try:
+                async with Scope() as scope:
+                    scope.do(inner_raise(KeyError()))
+            except Concurrent[Concurrent[IndexError]]:
+                assert False
 
 
 class TestScoping:


### PR DESCRIPTION
Allows cascading of ``Concurrent`` exceptions. This pull request includes:

* [X] ``Concurrent`` exceptions may contain other ``Concurrent`` exceptions,
* [X] nested ``Concurrent`` exceptions may be ``.flattened()``,
* [x] updated documentation on handling ``Concurrent`` exceptions.

Closes #68.