### PR TITLE
Exception on exceeding an interval

### DIFF
--- a/usim/__init__.py
+++ b/usim/__init__.py
@@ -2,7 +2,8 @@ from typing import Coroutine
 
 from .__about__ import __version__  # noqa: F401
 from ._core.loop import Loop as _Loop
-from ._primitives.timing import Time, Eternity, Instant, interval, delay
+from ._primitives.timing import Time, Eternity, Instant, interval, delay,\
+    IntervalExceeded
 from ._primitives.flag import Flag
 from ._primitives.locks import Lock
 from ._primitives.context import until, Scope, VolatileTaskClosed
@@ -16,7 +17,7 @@ from ._basics.pipe import Pipe
 
 __all__ = [
     'run',
-    'time', 'eternity', 'instant', 'interval', 'delay',
+    'time', 'eternity', 'instant', 'interval', 'delay', 'IntervalExceeded',
     'until', 'Scope',
     'TaskCancelled', 'VolatileTaskClosed', 'TaskClosed', 'TaskState', 'CancelTask',
     'Concurrent',

--- a/usim/_primitives/timing.py
+++ b/usim/_primitives/timing.py
@@ -457,6 +457,10 @@ class Time:
 time = Time()
 
 
+class IntervalExceeded(Exception):
+    """An :py:func:`interval` was postponed too long"""
+
+
 async def interval(period) -> AsyncIterable[float]:
     """
     Iterate through time by intervals of ``period``
@@ -483,6 +487,8 @@ async def interval(period) -> AsyncIterable[float]:
     loop = __LOOP_STATE__.LOOP
     last_time = loop.time
     while True:
+        if time.now > last_time + period:
+            raise IntervalExceeded()
         await (time == last_time + period)
         last_time = loop.time
         yield last_time

--- a/usim/_primitives/timing.py
+++ b/usim/_primitives/timing.py
@@ -484,9 +484,8 @@ async def interval(period) -> AsyncIterable[float]:
     in the loop body - the pause is shortened as necessary.
     This effectively creates a "clock" that ticks every ``period``
     and runs the loop body.
-
-    If the interval cannot be adhered, e.g. because loop body is suspended for longer
-    than ``period``, :py:exc:`~.IntervalExceeded` is raised.
+    If the loop body is suspended for longer than ``period`` so that a regular
+    cannot be met, :py:exc:`~.IntervalExceeded` is raised.
 
     .. seealso:: :py:func:`~.delay` if you want to always *pause for* the same time
     """

--- a/usim/_primitives/timing.py
+++ b/usim/_primitives/timing.py
@@ -489,6 +489,8 @@ async def interval(period) -> AsyncIterable[float]:
 
     .. seealso:: :py:func:`~.delay` if you want to always *pause for* the same time
     """
+    if period < 0:
+        raise ValueError('period must not be negative')
     loop = __LOOP_STATE__.LOOP
     last_time = loop.time
     while True:
@@ -526,6 +528,8 @@ async def delay(period) -> AsyncIterable[float]:
 
     .. seealso:: :py:func:`~.interval` if you want to *resume at* regular times
     """
+    if period < 0:
+        raise ValueError('period must not be negative')
     loop = __LOOP_STATE__.LOOP
     while True:
         await suspend(delay=period, until=None)

--- a/usim/_primitives/timing.py
+++ b/usim/_primitives/timing.py
@@ -531,11 +531,11 @@ async def delay(period) -> AsyncIterable[float]:
     if period < 0:
         raise ValueError('period must not be negative')
     loop = __LOOP_STATE__.LOOP
-    if period == 0:
+    if period > 0:
         while True:
-            await postpone()
+            await suspend(delay=period, until=None)
             yield loop.time
     else:
         while True:
-            await suspend(delay=period, until=None)
+            await postpone()
             yield loop.time

--- a/usim/_primitives/timing.py
+++ b/usim/_primitives/timing.py
@@ -531,6 +531,11 @@ async def delay(period) -> AsyncIterable[float]:
     if period < 0:
         raise ValueError('period must not be negative')
     loop = __LOOP_STATE__.LOOP
-    while True:
-        await suspend(delay=period, until=None)
-        yield loop.time
+    if period == 0:
+        while True:
+            await postpone()
+            yield loop.time
+    else:
+        while True:
+            await suspend(delay=period, until=None)
+            yield loop.time

--- a/usim/_primitives/timing.py
+++ b/usim/_primitives/timing.py
@@ -458,7 +458,7 @@ time = Time()
 
 
 class IntervalExceeded(Exception):
-    """An :py:func:`interval` was postponed too long"""
+    """An :py:func:`interval` was suspended too long"""
 
 
 async def interval(period) -> AsyncIterable[float]:
@@ -466,6 +466,7 @@ async def interval(period) -> AsyncIterable[float]:
     Iterate through time by intervals of ``period``
 
     :param period: on each step, pause with a ``period`` since the last step
+    :raises IntervalExceeded: if the loop body is suspended for more than ``period``
 
     Asynchronous iteration pauses and provides the current time at each step.
 
@@ -480,7 +481,12 @@ async def interval(period) -> AsyncIterable[float]:
 
     Using interval causes iteration to *resume at* regular times,
     even if the current activity is :term:`suspended <Suspension>`
-    in the loop body - the pause is shortened if necessary.
+    in the loop body - the pause is shortened as necessary.
+    This effectively creates a "clock" that ticks every ``period``
+    and runs the loop body.
+
+    If the interval cannot be adhered, e.g. because loop body is suspended for longer
+    than ``period``, :py:exc:`~.IntervalExceeded` is raised.
 
     .. seealso:: :py:func:`~.delay` if you want to always *pause for* the same time
     """

--- a/usim_pytest/test_types/test_pipe.py
+++ b/usim_pytest/test_types/test_pipe.py
@@ -5,13 +5,6 @@ from usim import time, Pipe, Scope
 from ..utility import via_usim, assertion_mode
 
 
-async def aenumerate(aiterable, start=0):
-    count = start
-    async for item in aiterable:
-        yield count, item
-        count += 1
-
-
 class TestPipe:
     @assertion_mode
     @via_usim

--- a/usim_pytest/test_types/test_time.py
+++ b/usim_pytest/test_types/test_time.py
@@ -7,6 +7,13 @@ from usim import time, until, eternity, instant, delay, interval, IntervalExceed
 from ..utility import via_usim, assertion_mode
 
 
+async def aenumerate(aiterable, start=0):
+    count = start
+    async for item in aiterable:
+        yield count, item
+        count += 1
+
+
 class TestTime:
     @via_usim
     async def test_representable(self):

--- a/usim_pytest/test_types/test_time.py
+++ b/usim_pytest/test_types/test_time.py
@@ -190,3 +190,15 @@ class TestTimeIteration:
             assert True
         else:
             assert False
+
+    @via_usim
+    async def test_interval_exact(self):
+        try:
+            async for idx, _ in aenumerate(interval(20)):
+                await (time + 20)
+                if idx == 5:
+                    break
+        except IntervalExceeded:
+            assert False
+        else:
+            assert True

--- a/usim_pytest/test_types/test_time.py
+++ b/usim_pytest/test_types/test_time.py
@@ -173,3 +173,13 @@ class TestTimeIteration:
             if iteration == 5:
                 break
             iteration += 1
+
+    @via_usim
+    async def test_interval_exceeded(self):
+        iteration = 0
+        async for _ in interval(20):
+            await (time + 40)
+            iteration += 1
+            if iteration >= 2:
+                break
+        assert True

--- a/usim_pytest/test_types/test_time.py
+++ b/usim_pytest/test_types/test_time.py
@@ -160,6 +160,15 @@ class TestTimeCondition:
 
 class TestTimeIteration:
     @via_usim
+    async def test_misuse(self):
+        with pytest.raises(ValueError):
+            async for _ in delay(-1):
+                pass
+        with pytest.raises(ValueError):
+            async for _ in interval(-1):
+                pass
+
+    @via_usim
     async def test_delay(self):
         start, iteration = time.now, 0
         async for now in delay(20):

--- a/usim_pytest/test_types/test_time.py
+++ b/usim_pytest/test_types/test_time.py
@@ -180,6 +180,18 @@ class TestTimeIteration:
                 break
 
     @via_usim
+    async def test_delay_exact(self):
+        async for idx, _ in aenumerate(delay(0)):
+            assert time.now == 0
+            if idx > 5:
+                break
+        async for idx, _ in aenumerate(delay(0)):
+            assert time.now == idx * 5
+            await (time + 5)
+            if idx > 5:
+                break
+
+    @via_usim
     async def test_interval(self):
         start, iteration = time.now, 1
         async for now in interval(20):

--- a/usim_pytest/test_types/test_time.py
+++ b/usim_pytest/test_types/test_time.py
@@ -2,7 +2,7 @@ import math
 
 import pytest
 
-from usim import time, until, eternity, instant, delay, interval
+from usim import time, until, eternity, instant, delay, interval, IntervalExceeded
 
 from ..utility import via_usim, assertion_mode
 
@@ -176,10 +176,10 @@ class TestTimeIteration:
 
     @via_usim
     async def test_interval_exceeded(self):
-        iteration = 0
-        async for _ in interval(20):
-            await (time + 40)
-            iteration += 1
-            if iteration >= 2:
-                break
-        assert True
+        try:
+            async for _ in interval(20):
+                await (time + 40)
+        except IntervalExceeded:
+            assert True
+        else:
+            assert False

--- a/usim_pytest/test_types/test_time.py
+++ b/usim_pytest/test_types/test_time.py
@@ -183,6 +183,7 @@ class TestTimeIteration:
 
     @via_usim
     async def test_interval_exceeded(self):
+        """It is an error to exceed an interval"""
         try:
             async for _ in interval(20):
                 await (time + 40)
@@ -193,6 +194,7 @@ class TestTimeIteration:
 
     @via_usim
     async def test_interval_exact(self):
+        """It is not an error to exactly match an interval"""
         try:
             async for idx, _ in aenumerate(interval(20)):
                 await (time + 20)


### PR DESCRIPTION
This PR defines what happens if ``interval`` is exceeded. Changes include:

* [x] ``interval`` raises ``IntervalExceeded`` if the body is suspended too long,
* [x] ``interval`` and ``delay`` directly use raw suspend/postpone primitives,
* [x] added unit tests,
* [x] expanded documentation.

Closes #70.