### PR TITLE
Pipe transfer precision

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-timeout=30
+timeout=5

--- a/usim/_basics/pipe.py
+++ b/usim/_basics/pipe.py
@@ -75,7 +75,7 @@ class Pipe:
                 )
                 # At this point, we have been suspended for as long as calculated.
                 # Barring float *imprecision* we have transferred the desired volume.
-                break
+                transferred = total
             window_end = __LOOP_STATE__.LOOP.time
             transferred += (window_end - window_start) * window_throughput
         self._del_subscriber(identifier)

--- a/usim/_basics/pipe.py
+++ b/usim/_basics/pipe.py
@@ -73,6 +73,9 @@ class Pipe:
                 await suspend(
                     delay=(total - transferred) / window_throughput, until=None,
                 )
+                # At this point, we have been suspended for as long as calculated.
+                # Barring float *imprecision* we have transferred the desired volume.
+                break
             window_end = __LOOP_STATE__.LOOP.time
             transferred += (window_end - window_start) * window_throughput
         self._del_subscriber(identifier)

--- a/usim_pytest/test_types/test_pipe.py
+++ b/usim_pytest/test_types/test_pipe.py
@@ -66,3 +66,15 @@ class TestPipe:
             scope.do(pipe.transfer(total=1, throughput=2))
             scope.do(pipe.transfer(total=1, throughput=2))
         assert (time == 8)
+
+    @via_usim
+    async def test_transfer_inexact(self):
+        # Values adapted from MatterMiners/lapis#61
+        # Need to advance the simulation time to have a lower
+        # time resolution. This makes it more likely to round
+        # down the calculated transfer time.
+        await (time + 100)
+        pipe = Pipe(throughput=10)
+        async with Scope() as scope:
+            for _ in range(6):
+                scope.do(pipe.transfer(total=15))


### PR DESCRIPTION
This pull request fixes a problem reported in MatterMiners/lapis#61. Imprecisions in calculating the duration of ``Pipe.transfer`` caused an infinite loop when rounded away from the required time.