### PR TITLE
Document ResourceLevels

### DIFF
--- a/docs/source/api/usim.rst
+++ b/docs/source/api/usim.rst
@@ -152,6 +152,9 @@ blocked or waited for.
 :py:class:`usim.Capacities`
     Fixed supply of named resources which can be temporarily borrowed.
 
+:py:class:`usim.typing.ResourceLevels`
+    Current, expected or desired levels of resources.
+
 :py:exc:`usim.ResourcesUnavailable`
     Exception raised when an attempt to :py:meth:`~usim.Resources.claim`
     resources fails.

--- a/docs/source/api/usim.typing.rst
+++ b/docs/source/api/usim.typing.rst
@@ -4,7 +4,11 @@
 usim.typing module
 ==================
 
+.. py:module:: usim.typing
+    :synopsis: μSim type hints
+
 .. automodule:: usim.typing
     :members:
     :undoc-members:
     :show-inheritance:
+    :noindex:

--- a/docs/source/api/usim_resources.rst
+++ b/docs/source/api/usim_resources.rst
@@ -1,14 +1,23 @@
 Resource Modelling
 ==================
 
+Resource Containers
+-------------------
+
 .. autoclass:: usim.Resources
     :members:
 
 .. autoclass:: usim.Capacities
     :members:
 
+.. autoclass:: usim.typing.ResourceLevels
+    :members:
+
 .. autoexception:: usim.ResourcesUnavailable
     :members:
+
+Resource Transfer
+-----------------
 
 .. autoclass:: usim.Pipe
     :members:

--- a/usim/_basics/_resource_level.py
+++ b/usim/_basics/_resource_level.py
@@ -78,9 +78,6 @@ class ResourceLevels(Generic[T]):
     #: cache of currently used specialisations to avoid
     #: recreating/duplicating commonly used types
     __specialisation_cache__ = WeakValueDictionary()
-    #: instance of this specialisation
-    #: with all values as zero
-    __zero__: 'ResourceLevels' = None
 
     def __init__(self, **kwargs: T):
         raise TypeError(
@@ -164,9 +161,6 @@ def __specialise__(zero: T, names: Iterable[str]) -> Type[ResourceLevels[T]]:
         def __ne__(self, other):
             return not self == other
 
-    SpecialisedResourceLevels.__zero__ = SpecialisedResourceLevels(
-        **dict.fromkeys(fields, zero)
-    )
     ResourceLevels.__specialisation_cache__[fields] = SpecialisedResourceLevels
     return SpecialisedResourceLevels
 

--- a/usim/_basics/_resource_level.py
+++ b/usim/_basics/_resource_level.py
@@ -80,11 +80,15 @@ class ResourceLevels(Generic[T]):
     __specialisation_cache__ = WeakValueDictionary()
 
     def __init__(self, **kwargs: T):
+        spec_name = f'{__specialise__.__module__}.{__specialise__.__qualname__}'
         raise TypeError(
-            'Base class %r cannot be instantiated.' % self.__class__.__name__
-            + 'Use %s.%s to declare subtypes with valid resource level names.' % (
-                __specialise__.__module__, __specialise__.__name__
-            )
+            f'Base class {self.__class__.__name__} cannot be instantiated.\n'
+            '\n'
+            f'The {self.__class__.__name__} type is intended to be automatically\n'
+            'subclassed by resources. You should not encounter the base class during\n'
+            'well-behaved simulations.\n'
+            '\n'
+            f'Use {spec_name} to declare subtypes with valid resource level names.\n'
         )
 
     @abstractmethod

--- a/usim/_basics/_resource_level.py
+++ b/usim/_basics/_resource_level.py
@@ -15,7 +15,7 @@ class ResourceLevels(Generic[T]):
     __specialisation_cache__ = WeakValueDictionary()
     #: instance of this specialisation
     #: with all values as zero
-    zero = None  # type: ResourceLevels
+    __zero__ = None  # type: ResourceLevels
 
     def __init__(self, **kwargs: T):
         raise TypeError(
@@ -99,7 +99,7 @@ def __specialise__(zero: T, names: Iterable[str]) -> Type[ResourceLevels[T]]:
         def __ne__(self, other):
             return not self == other
 
-    SpecialisedResourceLevels.zero = SpecialisedResourceLevels(
+    SpecialisedResourceLevels.__zero__ = SpecialisedResourceLevels(
         **dict.fromkeys(fields, zero)
     )
     ResourceLevels.__specialisation_cache__[fields] = SpecialisedResourceLevels

--- a/usim/_basics/_resource_level.py
+++ b/usim/_basics/_resource_level.py
@@ -11,15 +11,67 @@ class ResourceLevels(Generic[T]):
     Common class for named resource levels
 
     Representation for the levels of multiple named resources. Every set of resources,
-    such as :py:class:`usim.Resources` or :py:class:`usim.Capacities`, specialises
-    :py:class:`~.ResourceLevels` to provide one attribute for each named resource.
+    such as :py:class:`usim.Resources` or :py:class:`usim.Capacities`, specializes a
+    :py:class:`~.ResourceLevels` subclass with one attribute for each named resource.
     For example, ``Resources(a=3, b=4)`` uses a :py:class:`~.ResourceLevels` with
     attributes ``a`` and ``b``.
+
+    .. code:: python3
+
+        from usim import Resources
+
+        resources = Resources(a=3, b=4)
+        print(resources.levels.a)  # 3
+        print(resources.levels.b)  # 4
+        print(resources.levels.c)  # raises AttributeError
 
     :py:class:`~.ResourceLevels` allow no additional attributes other than their
     initial resources, but their values may be changed.
     The special attribute :py:attr:`~.__zero__` is always present and provides
-    an instance where all values are zero.
+    an instance for which all values are zero.
+
+    Each resource always uses the same :py:class:`~.ResourceLevels` subtype.
+    Binary operators for comparisons and arithmetic can be applied for
+    instances of the same subtype.
+
+    .. describe::  levels_a + levels_b
+                   levels_a - levels_b
+
+        Elementwise addition/subtraction of values.
+
+    .. describe::  levels_a > levels_b
+                   levels_a >= levels_b
+                   levels_a <= levels_b
+                   levels_a < levels_b
+
+        Strict elementwise comparison of values.
+        :py:data:`True` if the comparison is satisfied by each element pair,
+        :py:data:`False` otherwise.
+
+    .. describe:: levels_a == levels_b
+
+        Total elementwise equality of values.
+        :py:data:`True` if each element pair is equal,
+        :py:data:`False` otherwise.
+        The inverse of ``levels_a != levels_b``.
+
+    .. describe:: levels_a != levels_b
+
+        Partial elementwise unequality of values.
+        :py:data:`False` if each element pair is equal,
+        :py:data:`True` otherwise.
+        The inverse of ``levels_a == levels_b``.
+
+    In addition, iteration on a :py:class:`~.ResourceLevels` subtype yields
+    ``field, value`` pairs. This is similar to :py:meth:`dict.items`.
+
+    .. describe:: for field, value in levels_a
+
+        Iterate over the current ``field, value`` pairs.
+
+    .. describe:: dict(levels_a)
+
+        Create :py:class:`dict` of ``field: value`` pairs.
     """
     __slots__ = ()
     __fields__ = ()  # type: Tuple[str]

--- a/usim/_basics/_resource_level.py
+++ b/usim/_basics/_resource_level.py
@@ -74,13 +74,13 @@ class ResourceLevels(Generic[T]):
         Create :py:class:`dict` of ``field: value`` pairs.
     """
     __slots__ = ()
-    __fields__ = ()  # type: Tuple[str]
+    __fields__: Tuple[str] = ()
     #: cache of currently used specialisations to avoid
     #: recreating/duplicating commonly used types
     __specialisation_cache__ = WeakValueDictionary()
     #: instance of this specialisation
     #: with all values as zero
-    __zero__ = None  # type: ResourceLevels
+    __zero__: 'ResourceLevels' = None
 
     def __init__(self, **kwargs: T):
         raise TypeError(

--- a/usim/_basics/_resource_level.py
+++ b/usim/_basics/_resource_level.py
@@ -25,10 +25,10 @@ class ResourceLevels(Generic[T]):
         print(resources.levels.b)  # 4
         print(resources.levels.c)  # raises AttributeError
 
-    :py:class:`~.ResourceLevels` allow no additional attributes other than their
-    initial resources, but their values may be changed.
-    The special attribute :py:attr:`~.__zero__` is always present and provides
-    an instance for which all values are zero.
+    :py:class:`~.ResourceLevels` subtypes allow no additional attributes other than
+    their initial resources, but their values may be changed.
+    Instantiating a subtype requires resource levels to be specified by keyword;
+    missing resource are set to zero.
 
     Each resource always uses the same :py:class:`~.ResourceLevels` subtype.
     Binary operators for comparisons and arithmetic can be applied for

--- a/usim/_basics/_resource_level.py
+++ b/usim/_basics/_resource_level.py
@@ -93,35 +93,35 @@ class ResourceLevels(Generic[T]):
 
     @abstractmethod
     def __add__(self, other: 'ResourceLevels[T]') -> 'ResourceLevels[T]':
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def __sub__(self, other: 'ResourceLevels[T]') -> 'ResourceLevels[T]':
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def __gt__(self, other: 'ResourceLevels[T]') -> bool:
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def __ge__(self, other: 'ResourceLevels[T]') -> bool:
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def __le__(self, other: 'ResourceLevels[T]') -> bool:
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def __lt__(self, other: 'ResourceLevels[T]') -> bool:
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def __eq__(self, other: 'ResourceLevels[T]') -> bool:
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def __ne__(self, other: 'ResourceLevels[T]') -> bool:
-        pass
+        raise NotImplementedError
 
     def __iter__(self):
         for field in self.__fields__:

--- a/usim/_basics/_resource_level.py
+++ b/usim/_basics/_resource_level.py
@@ -7,7 +7,20 @@ T = TypeVar('T')
 
 
 class ResourceLevels(Generic[T]):
-    """Base class for named resource levels"""
+    """
+    Common class for named resource levels
+
+    Representation for the levels of multiple named resources. Every set of resources,
+    such as :py:class:`usim.Resources` or :py:class:`usim.Capacities`, specialises
+    :py:class:`~.ResourceLevels` to provide one attribute for each named resource.
+    For example, ``Resources(a=3, b=4)`` uses a :py:class:`~.ResourceLevels` with
+    attributes ``a`` and ``b``.
+
+    :py:class:`~.ResourceLevels` allow no additional attributes other than their
+    initial resources, but their values may be changed.
+    The special attribute :py:attr:`~.__zero__` is always present and provides
+    an instance where all values are zero.
+    """
     __slots__ = ()
     __fields__ = ()  # type: Tuple[str]
     #: cache of currently used specialisations to avoid

--- a/usim/_basics/resource.py
+++ b/usim/_basics/resource.py
@@ -20,8 +20,8 @@ class BaseResources(Generic[T]):
     """
     Internal base class for resource types
     """
-    _levels_type = None  # type: Type[ResourceLevels[T]]
-    _available = None  # type: Tracked[ResourceLevels[T]]
+    _levels_type: Type[ResourceLevels[T]]
+    _available: Tracked[ResourceLevels[T]]
 
     @property
     def levels(self) -> ResourceLevels[T]:

--- a/usim/_basics/resource.py
+++ b/usim/_basics/resource.py
@@ -49,7 +49,7 @@ class BaseResources(Generic[T]):
         :return: async context to borrow resources
         """
         borrowed_levels = self._levels_type(**amounts)
-        assert self._levels_type.zero <= borrowed_levels,\
+        assert self._levels_type.__zero__ <= borrowed_levels,\
             'cannot borrow negative amounts'
         return BorrowedResources(self, borrowed_levels)
 
@@ -87,7 +87,7 @@ class BorrowedResources(BaseResources[T]):
     def __init__(self, resources: 'BaseResources', debits: ResourceLevels):
         self._resources = resources
         self._debits = debits
-        self._available = Tracked(self._levels_type.zero)
+        self._available = Tracked(self._levels_type.__zero__)
 
     async def __aenter__(self):
         # do not postpone if we can resume immediately
@@ -196,7 +196,7 @@ class Resources(BaseResources[T]):
             type(next(iter(capacity.values())))()  # bare type invocation must be zero
         self._levels_type = __specialise__(__zero__, capacity.keys())
         self._available = Tracked(self._levels_type(**capacity))
-        assert self._available >= self._levels_type.zero,\
+        assert self._available >= self._levels_type.__zero__,\
             'initial capacities must be greater than or equal to zero'
 
     async def set(self, **amounts: T):
@@ -210,7 +210,7 @@ class Resources(BaseResources[T]):
         below zero. If a resource is not specified, its level remains
         unchanged.
         """
-        assert self._levels_type.zero <= self._levels_type(**amounts),\
+        assert self._levels_type.__zero__ <= self._levels_type(**amounts),\
             'cannot increase by negative amounts'
         new_levels = dict(self._available.value).copy()
         new_levels.update(amounts)
@@ -228,7 +228,7 @@ class Resources(BaseResources[T]):
         unchanged.
         """
         delta = self._levels_type(**amounts)
-        assert self._levels_type.zero <= delta,\
+        assert self._levels_type.__zero__ <= delta,\
             'cannot increase by negative amounts'
         await self.__insert_resources__(delta)
 
@@ -244,8 +244,8 @@ class Resources(BaseResources[T]):
         level remains unchanged.
         """
         delta = self._levels_type(**amounts)
-        assert self._levels_type.zero <= delta,\
+        assert self._levels_type.__zero__ <= delta,\
             'cannot decrease by negative amounts'
-        assert self._levels_type.zero <= (self._available.value - delta),\
+        assert self._levels_type.__zero__ <= (self._available.value - delta),\
             'cannot decrease below zero'
         await self.__remove_resources__(delta)

--- a/usim_pytest/test_types/test_resource.py
+++ b/usim_pytest/test_types/test_resource.py
@@ -4,9 +4,33 @@ from typing import Type
 
 from usim import Scope, time, until
 from usim import Resources, Capacities, ResourcesUnavailable
+from usim.typing import ResourceLevels
 from usim._basics.resource import BaseResources
 
 from ..utility import via_usim, assertion_mode
+
+
+class TestResourceLevels:
+    def test_misuse(self):
+        with pytest.raises(TypeError):
+            ResourceLevels()
+        with pytest.raises(TypeError):
+            ResourceLevels(a=3, b=4)
+
+    def test_comparison(self):
+        resource_type = Resources(a=3, b=3).resource_type
+        assert resource_type(a=5, b=10) == resource_type(b=10, a=5)
+        assert resource_type(a=5, b=10) != resource_type(a=6, b=10)
+        assert resource_type(a=5, b=10) < resource_type(a=6, b=11)
+        assert not resource_type(a=5, b=10) < resource_type(a=6, b=10)
+        assert resource_type(a=5, b=10) <= resource_type(a=6, b=10)
+        assert resource_type(a=6, b=11) > resource_type(a=5, b=10)
+        assert not resource_type(a=6, b=10) > resource_type(a=5, b=10)
+        assert resource_type(a=6, b=10) >= resource_type(a=5, b=10)
+        assert resource_type(a=5, b=10) + resource_type(a=10, b=5) ==\
+            resource_type(b=15, a=15)
+        assert resource_type(a=25, b=20) - resource_type(a=10, b=5) ==\
+            resource_type(b=15, a=15)
 
 
 class BaseResourceCase:


### PR DESCRIPTION
This PR adds documentation for the ``usim.typing.ResourceLevels`` helper. Changes include:

* added ``usim.typing.ResourceLevels`` to resource topic page,
* expanded docstring for ``usim.typing.ResourceLevels``,
* removed unneeded ``usim.typing.ResourceLevels.zero`` field as invariants would be broken when mutating it.

Closes #74.