### PR TITLE
Fix for semmle issue about using value being always None as result

### DIFF
--- a/usim_pytest/utility.py
+++ b/usim_pytest/utility.py
@@ -74,8 +74,7 @@ def via_usim(test_case: Callable[..., Coroutine]):
             nonlocal test_completed
             await test_case(*args, **kwargs)
             test_completed = True
-        result = run(complete_test_case())
+        run(complete_test_case())
         if not test_completed:
             raise UnfinishedTest(test_case)
-        return result
     return run_test


### PR DESCRIPTION
Semmle marked some issues in our unit tests that the result of ``run`` that is always ``None`` is used and returned in our unit test wrapper. I simply removed storing the result to fix this issue.

Closes #57.