### PR TITLE
Resource comparisons

### DIFF
--- a/docs/source/api/usim_resources.rst
+++ b/docs/source/api/usim_resources.rst
@@ -4,6 +4,10 @@ Resource Modelling
 Resource Containers
 -------------------
 
+Resources support the comparison operations, such as ``==``, ``>=``, or ``<``.
+This derives a :py:class:`~usim.Comparison` that triggers when the Resources'
+levels reaches the desired value.
+
 .. autoclass:: usim.Resources
     :members:
 

--- a/usim/_basics/resource.py
+++ b/usim/_basics/resource.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Generic, Optional, Type
+from typing import TypeVar, Generic, Optional, Type, Union, Dict
 
 from .._core.loop import __LOOP_STATE__
 from ._resource_level import __specialise__, ResourceLevels
@@ -71,6 +71,36 @@ class BaseResources(Generic[T]):
             f'{key}={item}' for key, item in self._available.value
         )
         return f'{self.__class__.__name__}({content})'
+
+    def __eq__(self, other: Union[ResourceLevels[T], Dict[str, T]]):
+        if isinstance(other, dict):
+            other = self.resource_type(**other)
+        return self._available == other
+
+    def __ne__(self, other: Union[ResourceLevels[T], Dict[str, T]]):
+        if isinstance(other, dict):
+            other = self.resource_type(**other)
+        return self._available != other
+
+    def __gt__(self, other: Union[ResourceLevels[T], Dict[str, T]]):
+        if isinstance(other, dict):
+            other = self.resource_type(**other)
+        return self._available > other
+
+    def __ge__(self, other: Union[ResourceLevels[T], Dict[str, T]]):
+        if isinstance(other, dict):
+            other = self.resource_type(**other)
+        return self._available >= other
+
+    def __le__(self, other: Union[ResourceLevels[T], Dict[str, T]]):
+        if isinstance(other, dict):
+            other = self.resource_type(**other)
+        return self._available <= other
+
+    def __lt__(self, other: Union[ResourceLevels[T], Dict[str, T]]):
+        if isinstance(other, dict):
+            other = self.resource_type(**other)
+        return self._available < other
 
 
 class BorrowedResources(BaseResources[T]):


### PR DESCRIPTION
This PR allows using comparisons to derive conditions for resource levels. Changes include:

* [x] Resources support comparisons, such as ``==``, ``<=``, to their levels,
* [x] added unit tests,
* [x] added docs.

Closes #80.