### PR TITLE
Pipes should also support transfers of 0

### DIFF
--- a/docs/source/changes/84.pipe_zero.yaml
+++ b/docs/source/changes/84.pipe_zero.yaml
@@ -1,0 +1,7 @@
+category: changed
+summary: "Pipe transfers support totals of zero"
+description: |
+  Until now ``total``s were asserted to be greater than zero. Now also transfers
+  of ``0`` are supported.
+pull requests:
+- 84

--- a/usim/_basics/pipe.py
+++ b/usim/_basics/pipe.py
@@ -59,7 +59,7 @@ class Pipe:
         If ``throughput`` is not given, it defaults to the Pipe's
         :py:attr:`~.throughput` limit.
         """
-        assert total > 0, 'total must be positive'
+        assert total >= 0, 'total must be positive'
         assert throughput is None or throughput > 0,\
             'throughput must be positive or None'
         transferred = 0

--- a/usim_pytest/test_types/test_pipe.py
+++ b/usim_pytest/test_types/test_pipe.py
@@ -44,6 +44,12 @@ class TestPipe:
         assert (time == 5)
 
     @via_usim
+    async def test_transfer_zero(self):
+        pipe = Pipe(throughput=2)
+        await pipe.transfer(total=0)
+        assert (time == 0)
+
+    @via_usim
     async def test_transfer_congested(self):
         pipe = Pipe(throughput=2)
         await pipe.transfer(total=2, throughput=4)


### PR DESCRIPTION
For usability it would be great that pipes could also support `total`s of 0 for `transfer`. This PR therefore implements this and also comes with a unit test as well as the required change fragment.