### PR TITLE
Scope shutdown and exceptions

### DIFF
--- a/docs/source/changes/85.early_task_cancellation.yaml
+++ b/docs/source/changes/85.early_task_cancellation.yaml
@@ -1,0 +1,7 @@
+category: fixed
+summary: "Cancelling a Task early no longer cancels its parent scope"
+description: |
+  Cancelling a :py:class:`~usim.Task` was incorrectly flagged as a failure of the task.
+  This caused the parent :py:class:`~usim.Scope` to abort as well.
+pull requests:
+- 85

--- a/docs/source/changes/85.scope_shutdown_suppression.yaml
+++ b/docs/source/changes/85.scope_shutdown_suppression.yaml
@@ -1,0 +1,11 @@
+category: fixed
+summary: "Scopes no longer swallow exceptions during graceful shutdown"
+description: |
+  When a :py:class:`~usim.Scope` received a signal during graceful shutdown,
+  its fast shutdown path attempted to propagate the signal incorrectly.
+  Such late signals as well as concurrent exceptions are now explicitly
+  handled and propagated out of the scope as needed.
+issues:
+- 83
+pull requests:
+- 85

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -288,8 +288,6 @@ class Scope:
         """
         try:
             await self._await_children()
-            # we must always postpone to receive signals, even if there are no children
-            await postpone()
         except BaseException as err:
             if not self._aexit_forceful(type(err), err):
                 raise
@@ -332,7 +330,7 @@ class Scope:
             # we already have a privileged exception, there is nothing more important
             # propagate it
             return False
-        elif self._is_suppressed(exc_val):
+        elif self._is_suppressed(exc_val) or exc_type is None:
             # we do not have an exception to propagate, take whatever we can get
             privileged, concurrent = self._collect_exceptions()
             if privileged is not None or concurrent is not None:

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -247,12 +247,14 @@ class Scope:
                 exc_type, exc_val = type(err), err
                 if not self._propagate_exceptions(exc_type, exc_val):
                     raise
+                return True
             else:
                 return await self._aexit_graceful()
-        self._body_done._value = True
-        self._body_done.__trigger__()
-        # there was an exception, we have to abandon the scope
-        return self._aexit_forceful(exc_type, exc_val)
+        else:
+            self._body_done._value = True
+            self._body_done.__trigger__()
+            # there was an exception, we have to abandon the scope
+            return self._aexit_forceful(exc_type, exc_val)
 
     def _aexit_forceful(self, exc_type, exc_val) -> bool:
         """
@@ -291,7 +293,6 @@ class Scope:
         except BaseException as err:
             if not self._aexit_forceful(type(err), err):
                 raise
-            return self._aexit_forceful(type(err), err)
         else:
             # everybody is gone - we just handle the cleanup
             self._disable_interrupts()

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -238,6 +238,8 @@ class Scope:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+        # there was no exception, we regularly exited the loop body
+        # we wait for our children to finish or some interrupt to happen
         if exc_type is None:
             try:
                 # inform everyone that we are shutting down
@@ -245,39 +247,23 @@ class Scope:
                 await self._body_done.set()
                 await self._await_children()
             except BaseException as err:
-                exc_type, exc_val = type(err), err
-                if not self._aexit_forceful(exc_type, exc_val):
+                self._close_scope()
+                if self._propagate_exceptions(type(err), err):
                     raise
                 return True
-            else:
-                # everybody is gone - we just handle the cleanup
-                self._disable_interrupts()
-                self._close_volatile()
-                return not self._propagate_exceptions(None, None)
+        # there was an exception, we have to abandon the scope fast
+        # we do not want interrupts that conflict with our current exception
         else:
             self._body_done._value = True
             self._body_done.__trigger__()
-            # there was an exception, we have to abandon the scope
-            return self._aexit_forceful(exc_type, exc_val)
+        self._close_scope()
+        return not self._propagate_exceptions(exc_type, exc_val)
 
-    def _aexit_forceful(self, exc_type, exc_val) -> bool:
-        """
-        Exit with exception
-
-        This immediately closes all children without waiting for anything.
-        No further interrupts can occur during shutdown (this is a sync function).
-
-        If a fatal exception occurred in this scope or a child, the fatal
-        exception replaces all other exceptions in flight.
-        If the current exception is suppressed by the scope, any exceptions from
-        children are reraised as :py:exc:`~.Concurrent` errors.
-        """
-        # we already handle an exception, suppress
+    def _close_scope(self):
+        """Ultimately close the scope, its interrupts and all children"""
         self._disable_interrupts()
-        # reap all children now
         self._close_children()
         self._close_volatile()
-        return not self._propagate_exceptions(exc_type, exc_val)
 
     def _collect_exceptions(self)\
             -> Tuple[Optional[BaseException], Optional[Concurrent]]:

--- a/usim/_primitives/context.py
+++ b/usim/_primitives/context.py
@@ -1,7 +1,7 @@
 from typing import Coroutine, List, TypeVar, Any, Optional, Tuple
 
 from .._core.loop import __LOOP_STATE__, Interrupt as CoreInterrupt
-from .notification import Notification, postpone
+from .notification import Notification
 from .flag import Flag
 from .task import Task, TaskClosed, TaskCancelled, try_close
 from .concurrent_exception import Concurrent

--- a/usim/_primitives/task.py
+++ b/usim/_primitives/task.py
@@ -118,7 +118,7 @@ class Task(Awaitable[RT]):
             # check for a pre-run cancellation
             if self._result is not None:
                 try_close(self.payload)
-                self.parent.__child_finished__(self, failed=True)
+                self.parent.__child_finished__(self, failed=False)
                 return
             try:
                 # We suspend the Task internally instead of waiting to start

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -181,7 +181,7 @@ class TestExceptions:
             # so that we cover every interrupt point in case the
             # implementation changes
             tasks = [scope.do(bare_scope()) for _ in range(5)]
-            for idx, task in enumerate(tasks):
+            for task in tasks:
                 assert not task.done
                 task.cancel()
                 await instant

--- a/usim_pytest/test_types/test_scope.py
+++ b/usim_pytest/test_types/test_scope.py
@@ -168,6 +168,7 @@ class TestExceptions:
     async def test_fail_interrupt_shutdown(self):
         """Interrupts during shutdown are not suppressed"""
         async def bare_scope():
+            await instant  # allow the task to postpone before we cancel it
             # a bare Scope postpones twice:
             # 1) signalling body done
             # 2) waiting for children (even if there are none)
@@ -177,7 +178,7 @@ class TestExceptions:
         async with Scope() as scope:
             task_bare = scope.do(bare_scope())
             task_child = scope.do(bare_scope())
-            await instant
+            await instant  # let tasks start; the next postponement is end of scope body
             assert not task_bare.done
             task_bare.cancel()
             await instant


### PR DESCRIPTION
This PR fixes some ill-specified corner-cases of scope shutdown. Changes include:

* [x] unittest to replicate exceptions on scope shutdown and task cancellation,
* [x] cancelling a task-to-be-started no longer cancels its scope,
* [x] scopes no longer suppress exceptions during shutdown.

Close #83.