### PR TITLE
Stream/async-generator cleanup

### DIFF
--- a/usim/_basics/streams.py
+++ b/usim/_basics/streams.py
@@ -168,7 +168,7 @@ class Queue(AsyncIterable, Generic[ST]):
             try:
                 return self._buffer.popleft()
             except IndexError:
-                assert self._closed  #
+                assert self._closed  # on failure, report this as a usim bug
                 raise StreamClosed(self)
 
     async def __aiter__(self):

--- a/usim/_basics/streams.py
+++ b/usim/_basics/streams.py
@@ -173,9 +173,11 @@ class Queue(AsyncIterable, Generic[ST]):
     async def __aiter__(self):
         while True:
             try:
-                yield await self
+                result = await self
             except StreamClosed:
                 break
+            else:
+                yield result
 
     async def put(self, item: ST):
         r"""

--- a/usim_pytest/test_types/test_streams.py
+++ b/usim_pytest/test_types/test_streams.py
@@ -20,12 +20,15 @@ class Base1to1Stream:
     async def test_close(self):
         stream = self.stream_type()
         await stream.close()
+        assert stream.closed
         with pytest.raises(StreamClosed):
             await stream.put(None)
         with pytest.raises(StreamClosed):
             await stream
+        # closing is idempotent
         with assert_postpone():
             await stream.close()
+        assert stream.closed
 
     @via_usim
     async def test_put_get(self):

--- a/usim_pytest/test_types/test_streams.py
+++ b/usim_pytest/test_types/test_streams.py
@@ -29,6 +29,7 @@ class Base1to1Stream:
 
     @via_usim
     async def test_put_get(self):
+        """``Stream.put`` interlocked with ``await Stream``"""
         stream = self.stream_type()
 
         async def fill(*values, delay: float = 5):
@@ -52,6 +53,7 @@ class Base1to1Stream:
 
     @via_usim
     async def test_put_stream(self):
+        """``Stream.put`` interlocked with ``async for ... in Stream``"""
         stream = self.stream_type()
 
         async def fill(*values, delay: float = 5):

--- a/usim_pytest/test_types/test_streams.py
+++ b/usim_pytest/test_types/test_streams.py
@@ -5,7 +5,7 @@ from usim import time, Scope
 from usim import Queue, Channel, StreamClosed
 from usim.typing import Stream
 
-from ..utility import via_usim, turnstamp
+from ..utility import via_usim, turnstamp, assert_postpone
 
 
 class Base1to1Stream:
@@ -24,10 +24,8 @@ class Base1to1Stream:
             await stream.put(None)
         with pytest.raises(StreamClosed):
             await stream
-        start = turnstamp()
-        await stream.close()
-        end = turnstamp()
-        assert end > start
+        with assert_postpone():
+            await stream.close()
 
     @via_usim
     async def test_put_get(self):

--- a/usim_pytest/test_types/test_streams.py
+++ b/usim_pytest/test_types/test_streams.py
@@ -5,7 +5,7 @@ from usim import time, Scope
 from usim import Queue, Channel, StreamClosed
 from usim.typing import Stream
 
-from ..utility import via_usim, turnstamp, assert_postpone
+from ..utility import via_usim, assert_postpone
 
 
 class Base1to1Stream:

--- a/usim_pytest/test_types/test_streams.py
+++ b/usim_pytest/test_types/test_streams.py
@@ -75,6 +75,20 @@ class Base1to1Stream:
 class Test1to1Queue(Base1to1Stream):
     stream_type = Queue
 
+    # Only applies to Queue since Channel does not buffer items
+    @via_usim
+    async def test_full_get(self):
+        """``await Queue`` on filled queue"""
+        stream = self.stream_type()
+
+        for val in range(20):
+            await stream.put(val)
+        await stream.close()
+        for val in range(20):
+            with assert_postpone():
+                fetched = await stream
+                assert fetched == val
+
 
 class Test1to1Channel(Base1to1Stream):
     stream_type = Channel


### PR DESCRIPTION
This PR cleans up the Queue async protocols. Changes include:

* [x] ``await queue`` always postpones to satisfy usim's guarantee that ``await`` runs other activities,
* [x] ``async for item in queue`` splits ``yield`` and ``await`` (see #86),
* [x] expanded unit tests for uncovered branches of Stream implementations.