### PR TITLE
infinite Pipe throughput

### DIFF
--- a/docs/source/api/usim_resources.rst
+++ b/docs/source/api/usim_resources.rst
@@ -25,3 +25,6 @@ Resource Transfer
 
 .. autoclass:: usim.Pipe
     :members:
+
+.. autoclass:: usim.UnboundedPipe
+    :members:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,4 @@
-.. Created by log.py at 2020-02-17, command
+.. Created by log.py at 2020-02-20, command
    '/Users/mfischer/PycharmProjects/usim/venv/lib/python3.7/site-packages/change/__main__.py log docs/source/changes compile --output docs/source/changelog.rst'
    based on the format of 'https://keepachangelog.com/'
 #########
@@ -8,9 +8,10 @@ ChangeLog
 Upcoming
 ========
 
-Version [Unreleased] - 2020-02-17
+Version [Unreleased] - 2020-02-20
 +++++++++++++++++++++++++++++++++
 
+* **[Changed]** Pipes allow for infinite throughput
 * **[Changed]** Pipe transfers support totals of zero
 
 * **[Fixed]** Scopes no longer swallow exceptions during graceful shutdown

--- a/docs/source/changes/89.infinite_pipes.yaml
+++ b/docs/source/changes/89.infinite_pipes.yaml
@@ -1,0 +1,10 @@
+category: changed
+summary: "Pipes allow for infinite throughput"
+description: |
+  For programming simplicity, it is useful to allow a :py:class:`~usim.Pipe` which
+  does not throttle throughput. This allows for a "neutral element" to disable effects
+  of a :py:class:`~usim.Pipe` without changing the design of a simulation. When it is
+  known up-front that unlimited throughput is desired, :py:class:`~usim.UnboundedPipe`
+  provides an optimal implementation for this case as well.
+pull requests:
+- 89

--- a/usim/__init__.py
+++ b/usim/__init__.py
@@ -12,7 +12,7 @@ from ._primitives.concurrent_exception import Concurrent
 from ._basics.streams import Channel, Queue, StreamClosed
 from ._basics.tracked import Tracked
 from ._basics.resource import Capacities, Resources, ResourcesUnavailable
-from ._basics.pipe import Pipe
+from ._basics.pipe import Pipe, UnboundedPipe
 
 
 __all__ = [
@@ -25,7 +25,7 @@ __all__ = [
     'Lock',
     'Channel', 'Queue', 'StreamClosed',
     'Capacities', 'Resources', 'ResourcesUnavailable',
-    'Pipe',
+    'Pipe', 'UnboundedPipe',
 ]
 
 

--- a/usim/_basics/pipe.py
+++ b/usim/_basics/pipe.py
@@ -124,4 +124,11 @@ class UnboundedPipe(Pipe):
         assert total >= 0, 'total must be positive'
         assert throughput is None or throughput > 0,\
             'throughput must be positive or None'
-        await postpone()
+        if throughput is None or throughput == float('inf'):
+            await postpone()
+        else:
+            delay = total / throughput
+            if delay > 0:
+                await suspend(delay=delay, until=None)
+            else:
+                await postpone()

--- a/usim/_basics/pipe.py
+++ b/usim/_basics/pipe.py
@@ -1,6 +1,6 @@
 from typing import Optional, Dict
 
-from .._primitives.notification import Notification, suspend
+from .._primitives.notification import Notification, suspend, postpone
 from .._core.loop import __LOOP_STATE__
 
 
@@ -96,3 +96,28 @@ class Pipe:
         elif self._throughput_scale != 1.0:
             self._throughput_scale = 1.0
             self._congested.__awake_all__()
+
+
+class UnboundedPipe(Pipe):
+    """
+    Shared transport for resources with unlimited total throughput
+
+    This is a noop variant of the regular :py:class:`~usim.Pipe`.
+    It serves as a neutral element when a :py:class:`~usim.Pipe`
+    is required but no throttling should take place.
+    """
+    def __init__(self, throughput=float('inf')):
+        assert throughput == float('inf'),\
+            'throughput must be infinite; use Pipe for finite throughput'
+        super().__init__(throughput=throughput)
+
+    async def transfer(
+            self, total: float, throughput: Optional[float] = None
+    ) -> None:
+        # Ensure that the outwards appearance is the same as the base:
+        # * fail on the same inputs
+        # * allow other tasks to run
+        assert total >= 0, 'total must be positive'
+        assert throughput is None or throughput > 0,\
+            'throughput must be positive or None'
+        await postpone()

--- a/usim_pytest/test_types/test_pipe.py
+++ b/usim_pytest/test_types/test_pipe.py
@@ -122,3 +122,8 @@ class TestUnboundedPipe:
 async def test_infinite_transfers(pipe_type):
     pipe = pipe_type(throughput=float('inf'))
     await pipe.transfer(total=20)
+    assert (time == 0)
+    await pipe.transfer(total=20, throughput=10)
+    assert (time == 2)
+    await pipe.transfer(total=0, throughput=10)
+    assert (time == 2)

--- a/usim_pytest/test_types/test_pipe.py
+++ b/usim_pytest/test_types/test_pipe.py
@@ -115,3 +115,10 @@ class TestUnboundedPipe:
                 scope.do(pipe.transfer(total=total))
                 scope.do(pipe.transfer(total=total))
         assert (time == 0)
+
+
+@pytest.mark.parametrize("pipe_type", [Pipe, UnboundedPipe])
+@via_usim
+async def test_infinite_transfers(pipe_type):
+    pipe = pipe_type(throughput=float('inf'))
+    await pipe.transfer(total=20)


### PR DESCRIPTION
This PR allows infinite ``throughput`` for ``Pipe`` resources. Changes include:

* changed ``Pipe.transfer`` to work for delays of 0 (implied by infinite throughput),
* added ``UnboundedPipe`` as an optimised pipe with infinite throughput,
* added unit tests.

The ``UnboundedPipe`` is currently *not* automatically used when instantiating ``Pipe(throughput=float('inf'))``. While this is possible, it might be unexpected when subclassing ``Pipe``.