### PR TITLE
added zenodo badge to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,22 @@
 μSim -- Simply Simulate
 =======================
 
+.. image:: https://readthedocs.org/projects/usim/badge/?version=latest
+    :target: http://usim.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation
+
+.. image:: https://img.shields.io/pypi/v/usim.svg
+    :target: https://pypi.python.org/pypi/usim/
+    :alt: Available on PyPI
+
+.. image:: https://img.shields.io/github/license/MaineKuehn/usim.svg
+    :target: https://github.com/MaineKuehn/usim/blob/master/LICENSE
+    :alt: MIT Licensed
+
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3813587.svg
+   :target: https://doi.org/10.5281/zenodo.3813587
+   :alt: Cite with DOI
+
 μSim offers a lightweight and expressive user interface,
 built on top of a powerful and robust simulation framework.
 Using the ``async``/``await`` capabilities of Python3,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@
    :alt: Cite with DOI
 
 .. toctree::
+   :hidden:
    :maxdepth: 1
    :caption: Contents:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,9 @@
 μSim - Lightweight Concurrent Simulations
 =========================================
 
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3813587.svg
+   :target: https://doi.org/10.5281/zenodo.3813587
+
 .. toctree::
    :maxdepth: 1
    :caption: Contents:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,18 @@
 μSim - Lightweight Concurrent Simulations
 =========================================
 
+.. image:: https://readthedocs.org/projects/usim/badge/?version=latest
+    :target: http://usim.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation
+
+.. image:: https://img.shields.io/pypi/v/usim.svg
+    :target: https://pypi.python.org/pypi/usim/
+    :alt: Available on PyPI
+
+.. image:: https://img.shields.io/github/license/MaineKuehn/usim.svg
+    :target: https://github.com/MaineKuehn/usim/blob/master/LICENSE
+    :alt: MIT Licensed
+
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3813587.svg
    :target: https://doi.org/10.5281/zenodo.3813587
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@
 
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3813587.svg
    :target: https://doi.org/10.5281/zenodo.3813587
+   :alt: Cite with DOI
 
 .. toctree::
    :maxdepth: 1

--- a/usim/__about__.py
+++ b/usim/__about__.py
@@ -17,6 +17,7 @@
 
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3813587.svg
    :target: https://doi.org/10.5281/zenodo.3813587
+   :alt: Cite with DOI
 
 μSim offers a lightweight and expressive user interface,
 built on top of a powerful and robust simulation framework.

--- a/usim/__about__.py
+++ b/usim/__about__.py
@@ -3,6 +3,18 @@
 ``usim`` -- Simply Simulate
 ===========================
 
+.. image:: https://readthedocs.org/projects/usim/badge/?version=latest
+    :target: http://usim.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation
+
+.. image:: https://img.shields.io/pypi/v/usim.svg
+    :target: https://pypi.python.org/pypi/usim/
+    :alt: Available on PyPI
+
+.. image:: https://img.shields.io/github/license/MaineKuehn/usim.svg
+    :target: https://github.com/MaineKuehn/usim/blob/master/LICENSE
+    :alt: MIT Licensed
+
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3813587.svg
    :target: https://doi.org/10.5281/zenodo.3813587
 

--- a/usim/__about__.py
+++ b/usim/__about__.py
@@ -3,6 +3,9 @@
 ``usim`` -- Simply Simulate
 ===========================
 
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3813587.svg
+   :target: https://doi.org/10.5281/zenodo.3813587
+
 μSim offers a lightweight and expressive user interface,
 built on top of a powerful and robust simulation framework.
 Using the ``async``/``await`` capabilities of Python3,


### PR DESCRIPTION
This PR updates the documentation with related information. Changes include:

* added badge to docs, README, pypi: docs, pypi, license, zenodo,
* hidden Table of Contents on docs landing page (sidebar still shows it),

The changed docs can be seen at the [temporary readthedocs build for this branch](https://usim.readthedocs.io/en/docs-zenodo/). Closes #91.