### PR TITLE
Fixes for flake8 issues

### DIFF
--- a/usim/_primitives/concurrent_exception.py
+++ b/usim/_primitives/concurrent_exception.py
@@ -143,8 +143,8 @@ class MetaConcurrent(type):
             Union[
                 Type[Exception],
                 'Type[Concurrent]',
-                'ellipsis',
-                'Tuple[Union[Type[Concurrent], Type[Exception], "ellipsis"], ...]',
+                'ellipsis',  # noqa
+                'Tuple[Union[Type[Concurrent], Type[Exception], "ellipsis"], ...]',  # noqa
             ]
     ):
         """``cls[item]`` - used to specialise ``cls`` with ``item``"""

--- a/usim/_primitives/task.py
+++ b/usim/_primitives/task.py
@@ -174,7 +174,7 @@ class Task(Awaitable[RT]):
     def __exception__(self) -> Optional[BaseException]:
         """Get the exception of this task"""
         assert self._result is not None,\
-            f'Task.__exception__ may only be queried for finished tasks'
+            'Task.__exception__ may only be queried for finished tasks'
         return self._result[1]
 
     @property

--- a/usim/py/events.py
+++ b/usim/py/events.py
@@ -411,7 +411,7 @@ class Process(Event[V]):
     def __init__(self, env: 'Environment', generator: Generator[None, Event, V]):
         if not hasattr(generator, 'send') and not hasattr(generator, 'throw'):
             raise ValueError(
-                f"'generator' argument must implement 'throw' and 'send'"
+                "'generator' argument must implement 'throw' and 'send'"
             )
         super().__init__(env)
         self._generator = generator


### PR DESCRIPTION
As mentioned in #95 we had several issues with flake8 regarding types with `ellipsis` and `fstrings` without placeholders.
This is fixed with this PR.

Closes #95.