### PR TITLE
Compatibility with SimPy 4

### DIFF
--- a/docs/source/api/usim.py.rst
+++ b/docs/source/api/usim.py.rst
@@ -3,7 +3,7 @@ SimPy compatibility API Reference
 
 .. container:: left-col
 
-    The :py:mod:`usim.py` package recreates the API of the :py:mod:`simpy` package.
+    The :py:mod:`usim.py` package recreates the v4 API of the :py:mod:`simpy` package.
     It serves as a drop-in replacement for SimPy in order to gradually integrate
     and migrate simulations to μSim. For use in an existing SimPy simulation,
     it is sufficient to import :py:mod:`usim.py` in place of :py:mod:`simpy`.

--- a/docs/source/changes/102.simpy4.yaml
+++ b/docs/source/changes/102.simpy4.yaml
@@ -1,0 +1,10 @@
+category: changed
+summary: "SimPy4 compatibility layer"
+description: |
+  The :py:mod:`usim.py` compatibility layer matches version 4 of the
+  :py:mod:`simpy` package. In specific, :py:meth:`usim.py.Environment.exit`
+  is deprecated and has been removed.
+issues:
+- 97
+pull requests:
+- 102

--- a/usim/py/core.py
+++ b/usim/py/core.py
@@ -14,7 +14,7 @@ from .. import time, run as usim_run, Concurrent
 from .. import Scope
 
 from .events import Event
-from .exceptions import NotCompatibleError, StopSimulation, StopProcess
+from .exceptions import NotCompatibleError, StopSimulation
 
 
 class EnvironmentScope(Scope):
@@ -172,17 +172,6 @@ class Environment:
                 "\n"
                 "You may 'env.run' outside of a 'usim' simulation"
             )
-
-    def exit(self, value=None):
-        """
-        Stop the current process, optionally providing a ``value``
-
-        .. warning::
-
-            This method exists for historical compatibility only.
-            Use ``return value`` instead.
-        """
-        raise StopProcess(value)
 
     def step(self):
         """

--- a/usim/py/events.py
+++ b/usim/py/events.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, TypeVar, Generic, Union, Tuple, Optional, Gene
 from .. import Flag, time
 from .._primitives.condition import Any as AnyFlag
 
-from .exceptions import NotCompatibleError, Interrupt, StopProcess
+from .exceptions import NotCompatibleError, Interrupt
 from ._awaitable import AwaitableEvent
 if TYPE_CHECKING:
     from .core import Environment
@@ -446,7 +446,7 @@ class Process(Event[V]):
                     env.active_process = self
                     self.target = event = generator.throw(event.value)
                     env.active_process = None
-            except (StopIteration, StopProcess) as err:
+            except StopIteration as err:
                 value = err.args[0] if err.args else None
                 self.succeed(value)
                 break

--- a/usim/py/exceptions.py
+++ b/usim/py/exceptions.py
@@ -20,20 +20,6 @@ class SimPyException(Exception):
     """Base case for exceptions that can safely be handled in a simulation"""
 
 
-class StopProcess(SimPyException):
-    """
-    Signal to stop a process
-
-    .. warning::
-
-        This exception exists for historical compatibility only.
-        See :py:meth:`usim.py.Environment.exit` for details.
-    """
-    def __init__(self, value):
-        super().__init__(value)
-        self.value = value
-
-
 class Interrupt(SimPyException):
     """Exception used to :py:meth:`~usim.py.events.Process.interrupt` a process"""
     @property

--- a/usim_pytest/test_usimpy/test_events.py
+++ b/usim_pytest/test_usimpy/test_events.py
@@ -188,15 +188,6 @@ class TestProcess:
         assert not process.is_alive
         assert env.active_process is not process
 
-    def test_env_exit(self, env):
-        def proc(env):
-            yield env.timeout(1)
-            env.exit(42)
-
-        process = env.process(proc(env))
-        env.run(5)
-        assert process.value == 42
-
     def test_error_raised(self, env):
         def proc(env):
             yield env.timeout(1)


### PR DESCRIPTION
This PR adjusts the ``usim.py`` compatibility layer to match SimPy 4. Changes include

* removed ``StopProcess`` and ``Environment.exit`` without replacement.

SimPy4 removed ``BaseEnvironment``, which ``usim.py`` did not provide in the first place.

See also #97.