### PR TITLE
Add `typing_extensions` to the dependencies to avoid installation issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ classifiers = [
 ]
 requires = [
     "sortedcontainers",
-    "asyncstdlib>=1.1.1"
+    "asyncstdlib>=1.1.1",
+    "typing_extensions>=3.10.0",
 ]
 
 [tool.flit.metadata.requires-extra]


### PR DESCRIPTION
Adding `usim` as a dependency to a complex Python project led to the build breaking, apparently because of missing `typing_extensions` in `usim`'s setup. This prevented `usim` from being installed in the Python virtual environment.

It seems like this dependency wasn't explicitly listed in the project dependency list. This did not break the usim builds, presumably because `typing_extensions` ended up getting installed before `usim` in the CI/dev environments.

This PR fixes this issue by making the dependency explicit.

Below is a sample error caused by `typing_extensions` in the (`pyenv`) virtual environment setup (some paths were trimmed for privacy reasons):
```
Collecting usim
  Cloning https://github.com/MaineKuehn/usim (to revision 4d8fa8a) to /tmp/pip-install-elfji2qz/usim
  WARNING: Did not find branch or tag '4d8fa8a', assuming revision or ref.
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
    Preparing wheel metadata ... error
    ERROR: Command errored out with exit status 1:
     command: <snip>/python3.8 <snip>/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpyhwh4i94                                                                                                                                                                                                              
cwd: /tmp/pip-install-elfji2qz/usim                                                                                                                                                                                             
Complete output (30 lines):                                                                                                                                                                                                          
Traceback (most recent call last):                                                                                                                                                                                                     
File "<snip>/_in_process.py", line 280, in <module>                                                                               
main()                                                                                                                                                                                                                             
File "<snip>/_in_process.py", line 263, in main                                                                                   json_out['return_val'] = hook(**hook_input['kwargs'])                                                                                                                                                                              
File "<snip>/_in_process.py", line 133, in prepare_metadata_for_build_wheel                                                       return hook(metadata_directory, config_settings)
      File "/tmp/pip-build-env-68spqj5t/overlay/lib/python3.8/site-packages/flit_core/buildapi.py", line 46, in prepare_metadata_for_build_wheel
        metadata = make_metadata(module, ini_info)
      File "/tmp/pip-build-env-68spqj5t/overlay/lib/python3.8/site-packages/flit_core/common.py", line 392, in make_metadata
        md_dict.update(get_info_from_module(module, ini_info.dynamic_metadata))
      File "/tmp/pip-build-env-68spqj5t/overlay/lib/python3.8/site-packages/flit_core/common.py", line 189, in get_info_from_module
        docstring, version = get_docstring_and_version_via_import(target)
      File "/tmp/pip-build-env-68spqj5t/overlay/lib/python3.8/site-packages/flit_core/common.py", line 165, in get_docstring_and_version_via_import
        m = sl.load_module()
      File "<frozen importlib._bootstrap_external>", line 462, in _check_name_wrapper
      File "<frozen importlib._bootstrap_external>", line 962, in load_module
      File "<frozen importlib._bootstrap_external>", line 787, in load_module
      File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
      File "<frozen importlib._bootstrap>", line 702, in _load
      File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 783, in exec_module
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "/tmp/pip-install-elfji2qz/usim/usim/__init__.py", line 5, in <module>
        from ._core.loop import Loop as _Loop
      File "/tmp/pip-install-elfji2qz/usim/usim/_core/loop.py", line 13, in <module>
        from .handler import __USIM_STATE__ as __LOOP_STATE__
      File "/tmp/pip-install-elfji2qz/usim/usim/_core/handler.py", line 7, in <module>
from typing_extensions import Protocol, Coroutine                                                                                                                                                                                
ModuleNotFoundError: No module named 'typing_extensions'                                                                                                                                                                             
----------------------------------------                                                                                                                                                                                         
ERROR: Command errored out with exit status 1: <snip>/python3.8 <snip>/_in_process.py 
prepare_metadata_for_build_wheel /tmp/tmpyhwh4i94 Check the logs for full command output.
```